### PR TITLE
fix: address security review findings (15 issues)

### DIFF
--- a/cmd/documcp/main.go
+++ b/cmd/documcp/main.go
@@ -11,8 +11,10 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/documcp/documcp/internal/api"
+	"github.com/documcp/documcp/internal/auth"
 	"github.com/documcp/documcp/internal/config"
 	"github.com/documcp/documcp/internal/crawler"
 	"github.com/documcp/documcp/internal/db"
@@ -47,7 +49,13 @@ func main() {
 		}
 	}
 
-	c := crawler.New(store, embedder)
+	// Derive the encryption key and create the shared token store.
+	// The same key is used by both the API server (for OAuth flows) and the
+	// crawler (to load stored tokens at crawl time).
+	key := deriveKey()
+	tokenStore := auth.NewTokenStore(store, key)
+
+	c := crawler.New(store, embedder).WithTokenStore(tokenStore)
 	scheduler := crawler.NewScheduler(c, store)
 	scheduler.Load(cfg)
 
@@ -62,15 +70,22 @@ func main() {
 		defer watcher.Stop()
 	}
 
-	key := deriveKey()
-
 	mcpServer := mcp.NewServer(store, embedder)
 	apiServer := api.NewServer(store, c, mcpServer.Handler(), key)
+
+	// Warn if no API key is configured — the API and MCP endpoints are open.
+	api.LogAPIKeyWarning()
 
 	addr := fmt.Sprintf(":%d", cfg.Server.Port)
 	slog.Info("starting DocuMcp", "addr", addr)
 
-	srv := &http.Server{Addr: addr, Handler: apiServer}
+	srv := &http.Server{
+		Addr:         addr,
+		Handler:      apiServer,
+		ReadTimeout:  30 * time.Second,
+		WriteTimeout: 60 * time.Second,
+		IdleTimeout:  120 * time.Second,
+	}
 	go func() {
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			slog.Error("server", "err", err)
@@ -82,9 +97,17 @@ func main() {
 	<-quit
 	signal.Stop(quit) // deregister so a second SIGINT uses the default handler
 	slog.Info("shutting down")
-	if err := srv.Shutdown(context.Background()); err != nil {
+
+	// Cancel background crawls started via the API.
+	apiServer.Shutdown()
+
+	// Give active HTTP connections up to 30 s to finish.
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer shutdownCancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
 		slog.Error("http shutdown", "err", err)
 	}
+
 	drainCtx := scheduler.Stop()
 	<-drainCtx.Done()
 }
@@ -93,6 +116,10 @@ func main() {
 // It reads DOCUMCP_SECRET_KEY (hex or base64-encoded 32 bytes). If the env
 // var is absent or invalid, a random ephemeral key is generated and a warning
 // is logged — tokens will not survive process restarts in that case.
+//
+// If the key changes between restarts, any tokens encrypted with the old key
+// will fail to decrypt. The crawler logs a clear error in that case and
+// proceeds unauthenticated; the user should re-authenticate via the UI.
 func deriveKey() []byte {
 	raw := os.Getenv("DOCUMCP_SECRET_KEY")
 	if raw != "" {

--- a/internal/adapter/azuredevops/azuredevops.go
+++ b/internal/adapter/azuredevops/azuredevops.go
@@ -38,7 +38,8 @@ func (a *AzureDevOpsAdapter) Crawl(ctx context.Context, src config.SourceConfig,
 	go func() {
 		defer close(ch)
 
-		token, _ := loadMicrosoftToken()
+		// src.Token is populated by the crawler from the token store.
+		token := src.Token
 		client := &http.Client{}
 
 		// Determine base API URL: adapter override wins, then source BaseURL.
@@ -149,9 +150,4 @@ func wikiPathToSlice(path string) []string {
 		result[i] = strings.ReplaceAll(p, "-", " ")
 	}
 	return result
-}
-
-// loadMicrosoftToken is a placeholder. Authentication is implemented in Task 14.
-func loadMicrosoftToken() (string, error) {
-	return "", nil
 }

--- a/internal/adapter/github/github.go
+++ b/internal/adapter/github/github.go
@@ -39,7 +39,8 @@ func (a *GitHubAdapter) Crawl(ctx context.Context, src config.SourceConfig, sour
 	go func() {
 		defer close(ch)
 
-		token, _ := loadGitHubToken()
+		// src.Token is populated by the crawler from the token store.
+		token := src.Token
 		client := &http.Client{}
 
 		// Fetch the full git tree for the wiki (recursive=1 flattens the tree).
@@ -148,9 +149,4 @@ func fileToTitle(path string) string {
 	name = strings.ReplaceAll(name, "-", " ")
 	name = strings.ReplaceAll(name, "_", " ")
 	return name
-}
-
-// loadGitHubToken is a placeholder. Authentication is implemented in Task 15.
-func loadGitHubToken() (string, error) {
-	return "", nil
 }

--- a/internal/adapter/web/web.go
+++ b/internal/adapter/web/web.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/documcp/documcp/internal/adapter"
 	"github.com/documcp/documcp/internal/config"
@@ -15,6 +17,12 @@ import (
 
 func init() {
 	adapter.Register("web", &WebAdapter{})
+}
+
+// crawlClient is the HTTP client used for all web crawl requests.
+// It has an explicit timeout to prevent hanging connections.
+var crawlClient = &http.Client{
+	Timeout: 30 * time.Second,
 }
 
 // WebAdapter crawls generic web documentation sites.
@@ -28,23 +36,45 @@ func (a *WebAdapter) Crawl(ctx context.Context, src config.SourceConfig, sourceI
 	if src.URL == "" {
 		return nil, fmt.Errorf("web adapter: source URL is required")
 	}
+
+	base, err := url.Parse(src.URL)
+	if err != nil {
+		return nil, fmt.Errorf("web adapter: parse source URL: %w", err)
+	}
+
 	ch := make(chan db.Page, 10)
-	client := http.DefaultClient
 
 	go func() {
 		defer close(ch)
 		sitemapURL := strings.TrimRight(src.URL, "/") + "/sitemap.xml"
-		urls, err := ParseSitemap(ctx, sitemapURL, client)
-		if err != nil || len(urls) == 0 {
+		allURLs, err := ParseSitemap(ctx, sitemapURL, crawlClient)
+		if err != nil || len(allURLs) == 0 {
 			// Fallback: just crawl the root URL
+			allURLs = []string{src.URL}
+		}
+
+		// Filter sitemap URLs: must share the same origin as the configured source
+		// URL and must not resolve to a blocked (SSRF-risk) host.
+		urls := make([]string, 0, len(allURLs))
+		for _, u := range allURLs {
+			parsed, parseErr := url.Parse(u)
+			if parseErr != nil {
+				continue
+			}
+			if !sameOrigin(parsed, base) {
+				slog.Warn("web: skipping cross-origin sitemap URL", "url", u, "base", src.URL)
+				continue
+			}
+			if !isAllowedHost(parsed) {
+				slog.Warn("web: skipping blocked host in sitemap URL", "url", u)
+				continue
+			}
+			urls = append(urls, u)
+		}
+		if len(urls) == 0 {
 			urls = []string{src.URL}
 		}
 
-		base, err := url.Parse(src.URL)
-		if err != nil {
-			slog.Error("web: parse base URL", "url", src.URL, "err", err)
-			return
-		}
 		visited := map[string]bool{}
 
 		for _, pageURL := range urls {
@@ -58,7 +88,7 @@ func (a *WebAdapter) Crawl(ctx context.Context, src config.SourceConfig, sourceI
 			}
 			visited[pageURL] = true
 
-			page, err := fetchPage(ctx, client, pageURL, sourceID, base)
+			page, err := fetchPage(ctx, crawlClient, pageURL, sourceID, base)
 			if err != nil {
 				slog.Warn("web: fetch page", "url", pageURL, "err", err)
 				continue
@@ -104,3 +134,58 @@ func urlToPath(u, base *url.URL) []string {
 	}
 	return parts
 }
+
+// sameOrigin returns true if u has the same scheme and host as base.
+func sameOrigin(u, base *url.URL) bool {
+	return u.Scheme == base.Scheme && strings.EqualFold(u.Host, base.Host)
+}
+
+// isAllowedHost returns false if the URL's host is a loopback, link-local,
+// or RFC-1918 private address — blocking SSRF via the crawler.
+func isAllowedHost(u *url.URL) bool {
+	host := u.Hostname()
+	if host == "" {
+		return false
+	}
+	// Block well-known internal hostnames.
+	lower := strings.ToLower(host)
+	if lower == "localhost" || strings.HasSuffix(lower, ".local") || strings.HasSuffix(lower, ".internal") {
+		return false
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		// Hostname — allow (full DNS resolution not feasible here).
+		return true
+	}
+	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+		return false
+	}
+	for _, cidr := range privateRanges {
+		if cidr.Contains(ip) {
+			return false
+		}
+	}
+	return true
+}
+
+// privateRanges lists CIDR blocks that must not be reachable via the crawler.
+var privateRanges = func() []*net.IPNet {
+	cidrs := []string{
+		"10.0.0.0/8",
+		"172.16.0.0/12",
+		"192.168.0.0/16",
+		"100.64.0.0/10", // Carrier-grade NAT (RFC 6598)
+		"169.254.0.0/16", // IPv4 link-local
+		"::1/128",        // IPv6 loopback
+		"fc00::/7",       // IPv6 unique local
+		"fe80::/10",      // IPv6 link-local
+	}
+	ranges := make([]*net.IPNet, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		_, network, err := net.ParseCIDR(cidr)
+		if err == nil {
+			ranges = append(ranges, network)
+		}
+	}
+	return ranges
+}()

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -17,12 +17,14 @@ import (
 )
 
 // githubClientID returns the GitHub OAuth app client ID to use for device flows.
-// Falls back to the well-known public client ID if the env var is not set.
+// Falls back to the well-known public DocuMcp GitHub App client ID if the env
+// var GITHUB_CLIENT_ID is not set. This is a public client ID safe to embed
+// in source code; it does not act as a secret.
 func githubClientID() string {
 	if id := os.Getenv("GITHUB_CLIENT_ID"); id != "" {
 		return id
 	}
-	return "178c6fc778ccc68e1d6a"
+	return "178c6fc778ccc68e1d6a" // public DocuMcp GitHub App client ID
 }
 
 // writeJSON writes v as JSON to w with the given status code.
@@ -38,6 +40,13 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 // writeError writes a JSON error body with the given status code.
 func writeError(w http.ResponseWriter, status int, msg string) {
 	writeJSON(w, status, map[string]string{"error": msg})
+}
+
+// internalError logs the full error and returns a generic 500 to the client,
+// preventing internal details (file paths, SQL errors, etc.) from leaking.
+func internalError(w http.ResponseWriter, op string, err error) {
+	slog.Error(op, "err", err)
+	writeError(w, http.StatusInternalServerError, "internal server error")
 }
 
 // parseID reads the path parameter named "id" and returns it as int64.
@@ -57,7 +66,7 @@ func parseID(w http.ResponseWriter, r *http.Request) (int64, bool) {
 func (s *Server) listSources(w http.ResponseWriter, r *http.Request) {
 	sources, err := s.store.ListSources()
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Errorf("list sources: %w", err).Error())
+		internalError(w, "list sources", err)
 		return
 	}
 	writeJSON(w, http.StatusOK, sources)
@@ -66,6 +75,9 @@ func (s *Server) listSources(w http.ResponseWriter, r *http.Request) {
 // createSource handles POST /api/sources.
 // Decodes a db.Source from the request body, inserts it, and returns 201 with the created source.
 func (s *Server) createSource(w http.ResponseWriter, r *http.Request) {
+	// Cap request body to 1 MiB to prevent memory exhaustion.
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+
 	var src db.Source
 	if err := json.NewDecoder(r.Body).Decode(&src); err != nil {
 		writeError(w, http.StatusBadRequest, fmt.Errorf("decode body: %w", err).Error())
@@ -74,13 +86,13 @@ func (s *Server) createSource(w http.ResponseWriter, r *http.Request) {
 
 	id, err := s.store.InsertSource(src)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Errorf("insert source: %w", err).Error())
+		internalError(w, "insert source", err)
 		return
 	}
 
 	created, err := s.store.GetSource(id)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Errorf("get source after insert: %w", err).Error())
+		internalError(w, "get source after insert", err)
 		return
 	}
 	writeJSON(w, http.StatusCreated, created)
@@ -99,12 +111,12 @@ func (s *Server) deleteSource(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusNotFound, "source not found")
 			return
 		}
-		writeError(w, http.StatusInternalServerError, fmt.Errorf("get source: %w", err).Error())
+		internalError(w, "get source", err)
 		return
 	}
 
 	if err := s.store.DeleteSource(id); err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Errorf("delete source: %w", err).Error())
+		internalError(w, "delete source", err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -121,16 +133,18 @@ func (s *Server) triggerCrawl(w http.ResponseWriter, r *http.Request) {
 	src, err := s.store.GetSource(id)
 	if err != nil {
 		if errors.Is(err, db.ErrNotFound) {
-			writeError(w, http.StatusNotFound, fmt.Errorf("get source: %w", err).Error())
+			writeError(w, http.StatusNotFound, "source not found")
 			return
 		}
-		writeError(w, http.StatusInternalServerError, fmt.Errorf("get source: %w", err).Error())
+		internalError(w, "get source", err)
 		return
 	}
 
 	if s.crawler != nil {
+		// Use the server's context so the goroutine is cancelled on shutdown.
+		crawlCtx := s.ctx
 		go func() {
-			if err := s.crawler.Crawl(context.Background(), *src); err != nil {
+			if err := s.crawler.Crawl(crawlCtx, *src); err != nil {
 				slog.Error("background crawl failed", "source_id", id, "err", err)
 			}
 		}()
@@ -150,7 +164,7 @@ func (s *Server) searchHandler(w http.ResponseWriter, r *http.Request) {
 
 	results, err := search.FTS(s.store, q, 20)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Errorf("search: %w", err).Error())
+		internalError(w, "search", err)
 		return
 	}
 	writeJSON(w, http.StatusOK, results)
@@ -171,7 +185,7 @@ func (s *Server) authStart(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusNotFound, "source not found")
 			return
 		}
-		writeError(w, http.StatusInternalServerError, fmt.Errorf("get source: %w", err).Error())
+		internalError(w, "get source", err)
 		return
 	}
 
@@ -181,7 +195,7 @@ func (s *Server) authStart(w http.ResponseWriter, r *http.Request) {
 		clientID := githubClientID()
 		ghFlow, err := auth.NewGitHubDeviceFlow("https://github.com", clientID)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, fmt.Errorf("start github device flow: %w", err).Error())
+			internalError(w, "start github device flow", err)
 			return
 		}
 		pf = pendingFlow{
@@ -194,16 +208,17 @@ func (s *Server) authStart(w http.ResponseWriter, r *http.Request) {
 		s.flowMu.Unlock()
 
 		slog.Info("auth start: GitHub device flow initiated", "source_id", id)
+		// device_code is a server-side secret used to poll the token endpoint;
+		// it must not be returned to the client where it could be exposed via XSS.
 		writeJSON(w, http.StatusOK, map[string]any{
 			"user_code":        ghFlow.UserCode,
 			"verification_uri": ghFlow.VerificationURI,
-			"device_code":      ghFlow.DeviceCode,
 			"expires_in":       int(time.Until(ghFlow.ExpiresAt).Seconds()),
 		})
 	} else {
 		msFlow, err := auth.NewMicrosoftDeviceFlow("https://login.microsoftonline.com", "common")
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, fmt.Errorf("start microsoft device flow: %w", err).Error())
+			internalError(w, "start microsoft device flow", err)
 			return
 		}
 		pf = pendingFlow{
@@ -215,10 +230,10 @@ func (s *Server) authStart(w http.ResponseWriter, r *http.Request) {
 		s.flowMu.Unlock()
 
 		slog.Info("auth start: Microsoft device flow initiated", "source_id", id)
+		// device_code is a server-side secret; omit it from the client response.
 		writeJSON(w, http.StatusOK, map[string]any{
 			"user_code":        msFlow.UserCode,
 			"verification_uri": msFlow.VerificationURI,
-			"device_code":      msFlow.DeviceCode,
 			"expires_in":       int(time.Until(msFlow.ExpiresAt).Seconds()),
 		})
 	}
@@ -279,7 +294,7 @@ func (s *Server) authPoll(w http.ResponseWriter, r *http.Request) {
 
 	// Token received — save it and remove the pending flow.
 	if err := s.tokenStore.Save(id, pf.provider, token); err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Errorf("save token: %w", err).Error())
+		internalError(w, "save token", err)
 		return
 	}
 	s.flowMu.Lock()
@@ -303,7 +318,7 @@ func (s *Server) authRevoke(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusNotFound, "source not found")
 			return
 		}
-		writeError(w, http.StatusInternalServerError, fmt.Errorf("get source: %w", err).Error())
+		internalError(w, "get source", err)
 		return
 	}
 
@@ -317,7 +332,7 @@ func (s *Server) authRevoke(w http.ResponseWriter, r *http.Request) {
 	for _, provider := range []string{"microsoft", "github"} {
 		if err := s.store.DeleteToken(id, provider); err != nil {
 			slog.Error("delete token", "source_id", id, "provider", provider, "err", err)
-			writeError(w, http.StatusInternalServerError, fmt.Errorf("delete token: %w", err).Error())
+			writeError(w, http.StatusInternalServerError, "internal server error")
 			return
 		}
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1,7 +1,13 @@
 package api
 
 import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net"
 	"net/http"
+	"os"
+	"strings"
 	"sync"
 
 	"github.com/documcp/documcp/internal/auth"
@@ -25,15 +31,19 @@ type Server struct {
 	crawler      *crawler.Crawler
 	mcpHandler   http.Handler
 	mux          *http.ServeMux
+	handler      http.Handler // full middleware chain, built once in NewServer
 	tokenStore   *auth.TokenStore
 	pendingFlows map[int64]*pendingFlow
 	flowMu       sync.Mutex
+	cancel       context.CancelFunc // cancels background work on Shutdown
+	ctx          context.Context    // cancelled when Shutdown is called
 }
 
 // NewServer creates a new API server wired to the given store, crawler, and MCP handler.
 // Pass nil for mcpHandler and/or crawler when not needed (e.g. in tests).
 // key must be exactly 32 bytes and is used for AES-256-GCM token encryption.
 func NewServer(store *db.Store, c *crawler.Crawler, mcpHandler http.Handler, key []byte) *Server {
+	ctx, cancel := context.WithCancel(context.Background())
 	s := &Server{
 		store:        store,
 		crawler:      c,
@@ -41,14 +51,26 @@ func NewServer(store *db.Store, c *crawler.Crawler, mcpHandler http.Handler, key
 		mux:          http.NewServeMux(),
 		tokenStore:   auth.NewTokenStore(store, key),
 		pendingFlows: make(map[int64]*pendingFlow),
+		ctx:          ctx,
+		cancel:       cancel,
 	}
 	s.routes()
+	// Build the middleware chain once at construction time.
+	apiKey := os.Getenv("DOCUMCP_API_KEY")
+	s.handler = securityMiddleware(apiKeyMiddleware(apiKey, s.mux))
 	return s
+}
+
+// Shutdown cancels background operations (e.g. in-progress crawls) started by
+// this server. It should be called during process shutdown after the HTTP
+// server has stopped accepting new requests.
+func (s *Server) Shutdown() {
+	s.cancel()
 }
 
 // ServeHTTP implements http.Handler.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	s.mux.ServeHTTP(w, r)
+	s.handler.ServeHTTP(w, r)
 }
 
 func (s *Server) routes() {
@@ -64,4 +86,83 @@ func (s *Server) routes() {
 		s.mux.Handle("/mcp/", s.mcpHandler)
 	}
 	s.mux.Handle("/", http.FileServer(web.FileSystem()))
+}
+
+// apiKeyMiddleware enforces Bearer token auth on /api/* and /mcp/* paths.
+// If DOCUMCP_API_KEY is empty the middleware is a no-op (open access, with a
+// warning logged at startup from main.go).
+func apiKeyMiddleware(apiKey string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if apiKey != "" {
+			path := r.URL.Path
+			if strings.HasPrefix(path, "/api/") || strings.HasPrefix(path, "/mcp/") {
+				got := r.Header.Get("Authorization")
+				if got != "Bearer "+apiKey {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusUnauthorized)
+					json.NewEncoder(w).Encode(map[string]string{"error": "unauthorized"}) //nolint:errcheck
+					return
+				}
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// securityMiddleware adds HTTP security headers to all responses and enforces
+// a restrictive CORS policy (only loopback origins are permitted).
+func securityMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h := w.Header()
+		h.Set("X-Content-Type-Options", "nosniff")
+		h.Set("X-Frame-Options", "DENY")
+		h.Set("Referrer-Policy", "no-referrer")
+		h.Set("Content-Security-Policy",
+			"default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'")
+
+		// CORS: only allow cross-origin requests from loopback addresses.
+		// Requests from external sites are denied by omitting the header.
+		if origin := r.Header.Get("Origin"); origin != "" {
+			if isLoopbackOrigin(origin) {
+				h.Set("Access-Control-Allow-Origin", origin)
+				h.Set("Vary", "Origin")
+				h.Set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
+				h.Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
+			}
+		}
+
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// isLoopbackOrigin returns true when the origin URL's host is a loopback address.
+func isLoopbackOrigin(origin string) bool {
+	// Strip scheme to get host (origin is scheme://host[:port])
+	after, ok := strings.CutPrefix(origin, "http://")
+	if !ok {
+		after, _ = strings.CutPrefix(origin, "https://")
+	}
+	// Remove port if present
+	host, _, err := net.SplitHostPort(after)
+	if err != nil {
+		host = after // no port
+	}
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+// logAPIKeyWarning logs a startup warning when no API key is configured.
+// Call once from main after creating the server.
+func LogAPIKeyWarning() {
+	if os.Getenv("DOCUMCP_API_KEY") == "" {
+		slog.Warn("DOCUMCP_API_KEY not set — API and MCP endpoints are unauthenticated")
+	}
 }

--- a/internal/auth/github_auth.go
+++ b/internal/auth/github_auth.go
@@ -41,6 +41,9 @@ func NewGitHubDeviceFlow(baseURL, clientID string) (*GitHubDeviceFlow, error) {
 		return nil, fmt.Errorf("device code request: %w", err)
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("device code request failed: HTTP %d", resp.StatusCode)
+	}
 
 	var result struct {
 		DeviceCode      string `json:"device_code"`

--- a/internal/auth/microsoft.go
+++ b/internal/auth/microsoft.go
@@ -36,6 +36,9 @@ func NewMicrosoftDeviceFlow(baseURL, tenant string) (*MicrosoftDeviceFlow, error
 		return nil, fmt.Errorf("device code request: %w", err)
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("device code request failed: HTTP %d", resp.StatusCode)
+	}
 
 	var result struct {
 		DeviceCode      string `json:"device_code"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,8 @@ type SourceConfig struct {
 	SpaceKey string `yaml:"space_key,omitempty"`
 	// scheduling
 	CrawlSchedule string `yaml:"crawl_schedule,omitempty"`
+	// Token is populated at runtime from the token store and never read from YAML.
+	Token string `yaml:"-"`
 }
 
 func Load(path string) (*Config, error) {

--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -2,6 +2,7 @@ package crawler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -9,6 +10,7 @@ import (
 	_ "github.com/documcp/documcp/internal/adapter/azuredevops"
 	_ "github.com/documcp/documcp/internal/adapter/github"
 	_ "github.com/documcp/documcp/internal/adapter/web"
+	"github.com/documcp/documcp/internal/auth"
 	"github.com/documcp/documcp/internal/config"
 	"github.com/documcp/documcp/internal/db"
 	"github.com/documcp/documcp/internal/embed"
@@ -17,13 +19,34 @@ import (
 // Crawler dispatches crawl jobs to the appropriate adapter, persists pages,
 // and optionally computes embeddings for semantic search.
 type Crawler struct {
-	store    *db.Store
-	embedder *embed.Embedder // nil = skip embeddings
+	store      *db.Store
+	embedder   *embed.Embedder  // nil = skip embeddings
+	tokenStore *auth.TokenStore // nil = no token loading
 }
 
 // New returns a new Crawler. Pass nil for embedder to skip embedding generation.
 func New(store *db.Store, embedder *embed.Embedder) *Crawler {
 	return &Crawler{store: store, embedder: embedder}
+}
+
+// WithTokenStore sets the token store used to load OAuth tokens for adapters
+// that require authentication. It returns the Crawler for chaining.
+func (c *Crawler) WithTokenStore(ts *auth.TokenStore) *Crawler {
+	c.tokenStore = ts
+	return c
+}
+
+// providerForType returns the OAuth provider name for a given source type,
+// or empty string if the type does not require OAuth.
+func providerForType(sourceType string) string {
+	switch sourceType {
+	case "github_wiki":
+		return "github"
+	case "azure_devops":
+		return "microsoft"
+	default:
+		return ""
+	}
 }
 
 // Crawl dispatches to the correct adapter, consumes the pages channel,
@@ -35,6 +58,26 @@ func (c *Crawler) Crawl(ctx context.Context, src db.Source) error {
 	}
 
 	cfgSrc := sourceToConfig(src)
+
+	// Load OAuth token from the store and inject it into the source config so
+	// adapters can use it without calling stub functions.
+	if c.tokenStore != nil {
+		if provider := providerForType(src.Type); provider != "" {
+			token, err := c.tokenStore.Load(src.ID, provider)
+			if err != nil {
+				if errors.Is(err, db.ErrNotFound) {
+					slog.Warn("crawler: no token stored for source, proceeding unauthenticated",
+						"source_id", src.ID, "provider", provider)
+				} else {
+					slog.Error("crawler: load token failed, proceeding unauthenticated",
+						"source_id", src.ID, "provider", provider, "err", err)
+				}
+			} else {
+				cfgSrc.Token = token.AccessToken
+			}
+		}
+	}
+
 	pages, err := a.Crawl(ctx, cfgSrc, src.ID)
 	if err != nil {
 		return fmt.Errorf("crawl: %w", err)


### PR DESCRIPTION
Critical:
- Add DOCUMCP_API_KEY Bearer token auth middleware for /api/* and /mcp/* routes; logs a startup warning when unset (#1)
- Wire auth.TokenStore into the crawler so GitHub/Azure DevOps adapters load stored OAuth tokens instead of the placeholder stub (#2)

High:
- SSRF protection in web crawler: filter sitemap URLs to same origin, block loopback/RFC-1918/link-local IP ranges, use dedicated HTTP client with 30s timeout (#3, #4 partially)
- Add ReadTimeout/WriteTimeout/IdleTimeout to the HTTP server (#4)
- Wrap request body with http.MaxBytesReader (1 MiB) in createSource (#5)

Medium:
- Add internalError() helper: log full error with slog, return generic "internal server error" to client for all 500 paths (#6, #12)
- Add securityMiddleware with X-Content-Type-Options, X-Frame-Options, Referrer-Policy, Content-Security-Policy headers (#7)
- CORS policy: only allow cross-origin requests from loopback origins; deny all others by omitting Access-Control-Allow-Origin (#8)
- Remove device_code from authStart JSON response (#9)
- Validate HTTP status code before decoding OAuth device code responses in both GitHub and Microsoft flows (#10)
- Background crawls now use the server's cancellable context so they stop when the server shuts down (#11)

Low:
- Document the hardcoded GitHub OAuth client ID constant (#14)
- Log a clear actionable message when token decryption fails due to a key change; use 30s timeout for graceful HTTP server shutdown (#13, #15)
- Add config.SourceConfig.Token runtime field (yaml:"-") to carry the loaded OAuth token to adapters without changing the Adapter interface