### PR TITLE
fix: address 10 open code review findings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/documcp/documcp
 
-go 1.23
+go 1.26.0
 
 require (
 	github.com/asg017/sqlite-vec-go-bindings v0.1.6

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,13 @@
 module github.com/documcp/documcp
 
-go 1.26.0
+go 1.23
 
 require (
 	github.com/asg017/sqlite-vec-go-bindings v0.1.6
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/knights-analytics/hugot v0.6.3
 	github.com/mattn/go-sqlite3 v1.14.34
+	github.com/modelcontextprotocol/go-sdk v0.8.0
 	github.com/robfig/cron/v3 v3.0.1
 	golang.org/x/net v0.51.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -28,7 +29,6 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/knights-analytics/ortgenai v0.1.0 // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
-	github.com/modelcontextprotocol/go-sdk v0.8.0 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/internal/adapter/web/web.go
+++ b/internal/adapter/web/web.go
@@ -116,7 +116,10 @@ func fetchPage(ctx context.Context, client *http.Client, pageURL string, sourceI
 	if title == "" {
 		title = pageURL
 	}
-	u, _ := url.Parse(pageURL)
+	u, err := url.Parse(pageURL)
+	if err != nil {
+		return db.Page{}, fmt.Errorf("parse page URL %s: %w", pageURL, err)
+	}
 	path := urlToPath(u, base)
 	return db.Page{
 		SourceID: sourceID,

--- a/internal/auth/github_auth.go
+++ b/internal/auth/github_auth.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -134,25 +135,10 @@ func LoadGitHubTokenFromCLI() (string, error) {
 		return "", fmt.Errorf("read gh hosts: %w", err)
 	}
 	const marker = "  oauth_token: "
-	for _, line := range splitLines(string(data)) {
+	for _, line := range strings.Split(string(data), "\n") {
 		if len(line) > len(marker) && line[:len(marker)] == marker {
 			return line[len(marker):], nil
 		}
 	}
 	return "", nil
-}
-
-func splitLines(s string) []string {
-	var lines []string
-	start := 0
-	for i := 0; i < len(s); i++ {
-		if s[i] == '\n' {
-			lines = append(lines, s[start:i])
-			start = i + 1
-		}
-	}
-	if start < len(s) {
-		lines = append(lines, s[start:])
-	}
-	return lines
 }

--- a/internal/auth/microsoft.go
+++ b/internal/auth/microsoft.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 )
 
@@ -50,7 +49,7 @@ func NewMicrosoftDeviceFlow(baseURL, tenant string) (*MicrosoftDeviceFlow, error
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, fmt.Errorf("decode device code response: %w", err)
 	}
-	tokenEndpoint := strings.Replace(endpoint, "/devicecode", "/token", 1)
+	tokenEndpoint := fmt.Sprintf("%s/%s/oauth2/v2.0/token", baseURL, tenant)
 	return &MicrosoftDeviceFlow{
 		DeviceCode:      result.DeviceCode,
 		UserCode:        result.UserCode,

--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -85,12 +85,13 @@ func (c *Crawler) Crawl(ctx context.Context, src db.Source) error {
 
 	count := 0
 	for page := range pages {
-		if err := c.store.UpsertPage(page); err != nil {
+		pageID, err := c.store.UpsertPage(page)
+		if err != nil {
 			slog.Error("upsert page", "url", page.URL, "err", err)
 			continue
 		}
 		if c.embedder != nil {
-			if err := c.indexEmbedding(ctx, page); err != nil {
+			if err := c.indexEmbedding(ctx, pageID, page); err != nil {
 				slog.Error("embed page", "url", page.URL, "err", err)
 			}
 		}
@@ -99,17 +100,13 @@ func (c *Crawler) Crawl(ctx context.Context, src db.Source) error {
 	return c.store.UpdateSourcePageCount(src.ID, count)
 }
 
-// indexEmbedding fetches the stored page ID and upserts its embedding.
-func (c *Crawler) indexEmbedding(ctx context.Context, page db.Page) error {
-	p, err := c.store.GetPageByURL(page.URL)
-	if err != nil {
-		return fmt.Errorf("get page by url: %w", err)
-	}
+// indexEmbedding generates and stores the embedding vector for a page.
+func (c *Crawler) indexEmbedding(ctx context.Context, pageID int64, page db.Page) error {
 	vecs, err := c.embedder.Embed([]string{page.Title + " " + page.Content})
 	if err != nil {
 		return fmt.Errorf("embed: %w", err)
 	}
-	return c.store.UpsertEmbedding(p.ID, vecs[0])
+	return c.store.UpsertEmbedding(pageID, vecs[0])
 }
 
 // sourceToConfig maps a db.Source to a config.SourceConfig for adapter dispatch.

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -163,26 +163,28 @@ func (s *Store) UpdateSourcePageCount(id int64, count int) error {
 	return nil
 }
 
-// UpsertPage inserts or updates a page by URL.
-func (s *Store) UpsertPage(p Page) error {
+// UpsertPage inserts or updates a page by URL and returns the page's row ID.
+func (s *Store) UpsertPage(p Page) (int64, error) {
 	pathJSON, err := json.Marshal(p.Path)
 	if err != nil {
-		return fmt.Errorf("marshal path: %w", err)
+		return 0, fmt.Errorf("marshal path: %w", err)
 	}
-	_, err = s.db.Exec(
+	var id int64
+	err = s.db.QueryRow(
 		`INSERT INTO pages (source_id, url, title, content, path)
 		 VALUES (?, ?, ?, ?, ?)
 		 ON CONFLICT(url) DO UPDATE SET
-		   title     = excluded.title,
-		   content   = excluded.content,
-		   path      = excluded.path,
-		   updated_at = CURRENT_TIMESTAMP`,
+		   title      = excluded.title,
+		   content    = excluded.content,
+		   path       = excluded.path,
+		   updated_at = CURRENT_TIMESTAMP
+		 RETURNING id`,
 		p.SourceID, p.URL, p.Title, p.Content, string(pathJSON),
-	)
+	).Scan(&id)
 	if err != nil {
-		return fmt.Errorf("upsert page %q: %w", p.URL, err)
+		return 0, fmt.Errorf("upsert page %q: %w", p.URL, err)
 	}
-	return nil
+	return id, nil
 }
 
 // GetPageByURL returns a page by its URL.

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -62,7 +62,7 @@ func TestUpsertAndGetPage(t *testing.T) {
 		t.Fatalf("InsertSource: %v", err)
 	}
 
-	err = store.UpsertPage(db.Page{
+	_, err = store.UpsertPage(db.Page{
 		SourceID: sourceID,
 		URL:      "https://example.com/page",
 		Title:    "Test Page",
@@ -96,10 +96,10 @@ func TestUpsertPage_UpdatesOnConflict(t *testing.T) {
 	if err != nil {
 		t.Fatalf("InsertSource: %v", err)
 	}
-	if err := store.UpsertPage(db.Page{SourceID: srcID, URL: "https://example.com/p", Title: "Old Title", Content: "old"}); err != nil {
+	if _, err := store.UpsertPage(db.Page{SourceID: srcID, URL: "https://example.com/p", Title: "Old Title", Content: "old"}); err != nil {
 		t.Fatalf("UpsertPage (first): %v", err)
 	}
-	if err := store.UpsertPage(db.Page{SourceID: srcID, URL: "https://example.com/p", Title: "New Title", Content: "new"}); err != nil {
+	if _, err := store.UpsertPage(db.Page{SourceID: srcID, URL: "https://example.com/p", Title: "New Title", Content: "new"}); err != nil {
 		t.Fatalf("UpsertPage (second): %v", err)
 	}
 
@@ -239,7 +239,7 @@ func TestUpsertEmbedding(t *testing.T) {
 		t.Fatalf("InsertSource: %v", err)
 	}
 
-	if err := store.UpsertPage(db.Page{
+	if _, err := store.UpsertPage(db.Page{
 		SourceID: srcID,
 		URL:      "https://example.com/embed-page",
 		Title:    "Embed Page",

--- a/internal/embed/embedder.go
+++ b/internal/embed/embedder.go
@@ -27,6 +27,7 @@ func New(modelPath string) (*Embedder, error) {
 		ModelPath:    modelPath,
 		Name:         "embedder",
 		OnnxFilename: "model.onnx",
+		Normalize:    true,
 	})
 	if err != nil {
 		_ = session.Destroy()
@@ -35,11 +36,10 @@ func New(modelPath string) (*Embedder, error) {
 	return &Embedder{session: session, pipeline: pipeline}, nil
 }
 
-// Embed returns one embedding vector per input text.
-// Vectors are the raw mean-pooled output of the model; normalization is NOT
-// applied. For cosine similarity (as used by sqlite-vec), either normalize
-// here with hugot.WithNormalization() or use sqlite-vec's vec_distance_cosine
-// function rather than dot product.
+// Embed returns one L2-normalised embedding vector per input text.
+// Normalisation is applied by the hugot pipeline so that L2 distance on
+// the stored unit vectors is equivalent to cosine distance, matching the
+// expectation in the page_embeddings schema.
 func (e *Embedder) Embed(texts []string) ([][]float32, error) {
 	output, err := e.pipeline.RunPipeline(texts)
 	if err != nil {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -142,10 +142,6 @@ func (s *Server) handleSearchDocs(_ context.Context, req *sdkmcp.CallToolRequest
 		}
 	}
 
-	if len(results) > finalLimit {
-		results = results[:finalLimit]
-	}
-
 	data, err := json.Marshal(results)
 	if err != nil {
 		return toolError(fmt.Sprintf("marshal results: %v", err))

--- a/internal/search/browse.go
+++ b/internal/search/browse.go
@@ -3,7 +3,6 @@ package search
 import (
 	"encoding/json"
 	"fmt"
-	"log/slog"
 
 	"github.com/documcp/documcp/internal/db"
 )
@@ -25,35 +24,27 @@ type PageRef struct {
 // with the page count per section. Returns make([]Section, 0) for an empty source.
 func BrowseTopLevel(store *db.Store, sourceID int64) ([]Section, error) {
 	rows, err := store.DB().Query(
-		`SELECT path FROM pages WHERE source_id = ?`, sourceID,
+		`SELECT json_extract(path, '$[0]') AS section, COUNT(*) AS cnt
+		 FROM pages
+		 WHERE source_id = ? AND json_extract(path, '$[0]') IS NOT NULL
+		 GROUP BY section`,
+		sourceID,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("browse top level: %w", err)
 	}
 	defer rows.Close()
 
-	counts := map[string]int{}
+	sections := make([]Section, 0)
 	for rows.Next() {
-		var pathJSON string
-		if err := rows.Scan(&pathJSON); err != nil {
+		var s Section
+		if err := rows.Scan(&s.Name, &s.PageCount); err != nil {
 			return nil, fmt.Errorf("browse top level scan: %w", err)
 		}
-		var path []string
-		if err := json.Unmarshal([]byte(pathJSON), &path); err != nil {
-			slog.Warn("browse: invalid path JSON", "err", err)
-			continue
-		}
-		if len(path) > 0 {
-			counts[path[0]]++
-		}
+		sections = append(sections, s)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("browse top level rows: %w", err)
-	}
-
-	sections := make([]Section, 0, len(counts))
-	for name, count := range counts {
-		sections = append(sections, Section{Name: name, PageCount: count})
 	}
 	return sections, nil
 }
@@ -62,7 +53,9 @@ func BrowseTopLevel(store *db.Store, sourceID int64) ([]Section, error) {
 // Returns make([]PageRef, 0) when there are no matches.
 func BrowseSection(store *db.Store, sourceID int64, section string) ([]PageRef, error) {
 	rows, err := store.DB().Query(
-		`SELECT url, title, path FROM pages WHERE source_id = ?`, sourceID,
+		`SELECT url, title, path FROM pages
+		 WHERE source_id = ? AND json_extract(path, '$[0]') = ?`,
+		sourceID, section,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("browse section: %w", err)
@@ -77,12 +70,9 @@ func BrowseSection(store *db.Store, sourceID int64, section string) ([]PageRef, 
 			return nil, fmt.Errorf("browse section scan: %w", err)
 		}
 		if err := json.Unmarshal([]byte(pathJSON), &ref.Path); err != nil {
-			slog.Warn("browse: invalid path JSON", "url", ref.URL, "err", err)
-			continue
+			return nil, fmt.Errorf("browse section unmarshal path %q: %w", ref.URL, err)
 		}
-		if len(ref.Path) > 0 && ref.Path[0] == section {
-			pages = append(pages, ref)
-		}
+		pages = append(pages, ref)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("browse section rows: %w", err)

--- a/internal/search/browse_test.go
+++ b/internal/search/browse_test.go
@@ -25,13 +25,13 @@ func setupBrowseDB(t *testing.T) (*db.Store, int64) {
 func TestBrowseTopLevel(t *testing.T) {
 	store, srcID := setupBrowseDB(t)
 
-	if err := store.UpsertPage(db.Page{SourceID: srcID, URL: "u1", Title: "Auth Overview", Path: []string{"Authentication", "Auth Overview"}}); err != nil {
+	if _, err := store.UpsertPage(db.Page{SourceID: srcID, URL: "u1", Title: "Auth Overview", Path: []string{"Authentication", "Auth Overview"}}); err != nil {
 		t.Fatalf("UpsertPage: %v", err)
 	}
-	if err := store.UpsertPage(db.Page{SourceID: srcID, URL: "u2", Title: "OAuth Setup", Path: []string{"Authentication", "OAuth Setup"}}); err != nil {
+	if _, err := store.UpsertPage(db.Page{SourceID: srcID, URL: "u2", Title: "OAuth Setup", Path: []string{"Authentication", "OAuth Setup"}}); err != nil {
 		t.Fatalf("UpsertPage: %v", err)
 	}
-	if err := store.UpsertPage(db.Page{SourceID: srcID, URL: "u3", Title: "Docker Guide", Path: []string{"Deployment", "Docker Guide"}}); err != nil {
+	if _, err := store.UpsertPage(db.Page{SourceID: srcID, URL: "u3", Title: "Docker Guide", Path: []string{"Deployment", "Docker Guide"}}); err != nil {
 		t.Fatalf("UpsertPage: %v", err)
 	}
 
@@ -58,13 +58,13 @@ func TestBrowseTopLevel(t *testing.T) {
 func TestBrowseSection(t *testing.T) {
 	store, srcID := setupBrowseDB(t)
 
-	if err := store.UpsertPage(db.Page{SourceID: srcID, URL: "u1", Title: "Auth Overview", Path: []string{"Authentication", "Auth Overview"}}); err != nil {
+	if _, err := store.UpsertPage(db.Page{SourceID: srcID, URL: "u1", Title: "Auth Overview", Path: []string{"Authentication", "Auth Overview"}}); err != nil {
 		t.Fatalf("UpsertPage: %v", err)
 	}
-	if err := store.UpsertPage(db.Page{SourceID: srcID, URL: "u2", Title: "OAuth Setup", Path: []string{"Authentication", "OAuth Setup"}}); err != nil {
+	if _, err := store.UpsertPage(db.Page{SourceID: srcID, URL: "u2", Title: "OAuth Setup", Path: []string{"Authentication", "OAuth Setup"}}); err != nil {
 		t.Fatalf("UpsertPage: %v", err)
 	}
-	if err := store.UpsertPage(db.Page{SourceID: srcID, URL: "u3", Title: "Docker Guide", Path: []string{"Deployment", "Docker Guide"}}); err != nil {
+	if _, err := store.UpsertPage(db.Page{SourceID: srcID, URL: "u3", Title: "Docker Guide", Path: []string{"Deployment", "Docker Guide"}}); err != nil {
 		t.Fatalf("UpsertPage: %v", err)
 	}
 
@@ -99,7 +99,7 @@ func TestBrowseTopLevel_EmptySource(t *testing.T) {
 func TestBrowseSection_NoMatch(t *testing.T) {
 	store, srcID := setupBrowseDB(t)
 
-	if err := store.UpsertPage(db.Page{SourceID: srcID, URL: "u1", Title: "Auth Overview", Path: []string{"Authentication", "Auth Overview"}}); err != nil {
+	if _, err := store.UpsertPage(db.Page{SourceID: srcID, URL: "u1", Title: "Auth Overview", Path: []string{"Authentication", "Auth Overview"}}); err != nil {
 		t.Fatalf("UpsertPage: %v", err)
 	}
 

--- a/internal/search/fts_test.go
+++ b/internal/search/fts_test.go
@@ -31,7 +31,7 @@ func TestFTS_ReturnsRelevantResults(t *testing.T) {
 		{SourceID: srcID, URL: "u3", Title: "Database Schema", Content: "PostgreSQL schema design and migration strategies"},
 	}
 	for _, p := range pages {
-		if err := store.UpsertPage(p); err != nil {
+		if _, err := store.UpsertPage(p); err != nil {
 			t.Fatalf("UpsertPage: %v", err)
 		}
 	}
@@ -54,7 +54,7 @@ func TestFTS_ReturnsEmptyForNoMatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("InsertSource: %v", err)
 	}
-	if err := store.UpsertPage(db.Page{SourceID: srcID, URL: "u1", Title: "Docker Guide", Content: "Running containers"}); err != nil {
+	if _, err := store.UpsertPage(db.Page{SourceID: srcID, URL: "u1", Title: "Docker Guide", Content: "Running containers"}); err != nil {
 		t.Fatalf("UpsertPage: %v", err)
 	}
 
@@ -74,7 +74,7 @@ func TestFTS_RespectsLimit(t *testing.T) {
 		t.Fatalf("InsertSource: %v", err)
 	}
 	for i := 0; i < 5; i++ {
-		if err := store.UpsertPage(db.Page{
+		if _, err := store.UpsertPage(db.Page{
 			SourceID: srcID,
 			URL:      fmt.Sprintf("u%d", i),
 			Title:    "Authentication Guide",

--- a/web/embed.go
+++ b/web/embed.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"embed"
+	"fmt"
 	"io/fs"
 	"net/http"
 )
@@ -10,7 +11,12 @@ import (
 var staticFiles embed.FS
 
 // FileSystem returns the embedded static file system as an http.FileSystem.
+// It panics if the embedded "static" subdirectory is missing, which indicates
+// a build-time packaging error.
 func FileSystem() http.FileSystem {
-	sub, _ := fs.Sub(staticFiles, "static")
+	sub, err := fs.Sub(staticFiles, "static")
+	if err != nil {
+		panic(fmt.Sprintf("web: embed sub: %v", err))
+	}
 	return http.FS(sub)
 }


### PR DESCRIPTION
Fixes the 10 remaining open findings from the code review in issue #3:

- #2 Embedding normalization (critical: semantic search rankings were wrong)
- #3 go.mod version corrected to go 1.23
- #4 Silent error discard in web/embed.go
- #5 BrowseSection/BrowseTopLevel O(n) scan replaced with SQL json_extract
- #6 UpsertPage returns ID via RETURNING, eliminating extra DB round-trip
- #7 Microsoft token endpoint built explicitly (not via strings.Replace)
- #8 splitLines replaced with strings.Split
- #9 url.Parse error handled in fetchPage
- #12 Dead code guard removed in mcp/tools.go
- #13 go-sdk moved to direct dependency in go.mod

Note: #11 (Alpine.js CDN vendoring) was skipped due to network access restrictions.

Generated with [Claude Code](https://claude.ai/code)