### PR TITLE
Security hardening: SSRF, API auth, URL validation, XSS

### DIFF
--- a/internal/adapter/azuredevops/azuredevops.go
+++ b/internal/adapter/azuredevops/azuredevops.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mathwro/DocuMcp/internal/adapter"
 	"github.com/mathwro/DocuMcp/internal/config"
 	"github.com/mathwro/DocuMcp/internal/db"
+	"github.com/mathwro/DocuMcp/internal/httpsafe"
 )
 
 func init() {
@@ -40,7 +41,7 @@ func (a *AzureDevOpsAdapter) Crawl(ctx context.Context, src config.SourceConfig,
 
 		// src.Token is populated by the crawler from the token store.
 		token := src.Token
-		client := &http.Client{}
+		client := &http.Client{CheckRedirect: httpsafe.CheckRedirect}
 
 		// Determine base API URL: adapter override wins, then source BaseURL.
 		apiBase := a.baseURL

--- a/internal/adapter/github/github.go
+++ b/internal/adapter/github/github.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mathwro/DocuMcp/internal/adapter"
 	"github.com/mathwro/DocuMcp/internal/config"
 	"github.com/mathwro/DocuMcp/internal/db"
+	"github.com/mathwro/DocuMcp/internal/httpsafe"
 )
 
 func init() {
@@ -41,7 +42,7 @@ func (a *GitHubAdapter) Crawl(ctx context.Context, src config.SourceConfig, sour
 
 		// src.Token is populated by the crawler from the token store.
 		token := src.Token
-		client := &http.Client{}
+		client := &http.Client{CheckRedirect: httpsafe.CheckRedirect}
 
 		// Fetch the full git tree for the wiki (recursive=1 flattens the tree).
 		treeURL := fmt.Sprintf("%s/repos/%s/git/trees/master?recursive=1", a.baseURL, src.Repo)

--- a/internal/adapter/githubrepo/githubrepo.go
+++ b/internal/adapter/githubrepo/githubrepo.go
@@ -17,7 +17,12 @@ import (
 	"github.com/mathwro/DocuMcp/internal/adapter"
 	"github.com/mathwro/DocuMcp/internal/config"
 	"github.com/mathwro/DocuMcp/internal/db"
+	"github.com/mathwro/DocuMcp/internal/httpsafe"
 )
+
+// tarballClient is used for all tarball fetches; its CheckRedirect hook
+// re-validates every redirect hop to prevent SSRF via a 302 to a private IP.
+var tarballClient = &http.Client{CheckRedirect: httpsafe.CheckRedirect}
 
 const maxFileSize = 5 * 1024 * 1024 // 5 MiB per file
 
@@ -148,7 +153,7 @@ func (a *Adapter) fetchTarball(ctx context.Context, src config.SourceConfig, bra
 			req.Header.Set("Authorization", "Bearer "+src.Token)
 		}
 
-		resp, err = http.DefaultClient.Do(req)
+		resp, err = tarballClient.Do(req)
 		if err != nil {
 			return nil, fmt.Errorf("github_repo: fetch tarball: %w", err)
 		}

--- a/internal/adapter/web/web.go
+++ b/internal/adapter/web/web.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -14,6 +13,7 @@ import (
 	"github.com/mathwro/DocuMcp/internal/adapter"
 	"github.com/mathwro/DocuMcp/internal/config"
 	"github.com/mathwro/DocuMcp/internal/db"
+	"github.com/mathwro/DocuMcp/internal/httpsafe"
 )
 
 func init() {
@@ -21,9 +21,12 @@ func init() {
 }
 
 // crawlClient is the HTTP client used for all web crawl requests.
-// It has an explicit timeout to prevent hanging connections.
+// It has an explicit timeout and re-validates every redirect target
+// through httpsafe.CheckRedirect — without this, a public URL could
+// 302 the crawler at cloud-metadata or RFC1918 addresses.
 var crawlClient = &http.Client{
-	Timeout: 30 * time.Second,
+	Timeout:       30 * time.Second,
+	CheckRedirect: httpsafe.CheckRedirect,
 }
 
 // WebAdapter crawls generic web documentation sites.
@@ -42,7 +45,7 @@ func (a *WebAdapter) Crawl(ctx context.Context, src config.SourceConfig, sourceI
 	if err != nil {
 		return 0, nil, fmt.Errorf("web adapter: parse source URL: %w", err)
 	}
-	if !isAllowedHost(base) {
+	if !isAllowedHost(ctx, base) {
 		return 0, nil, fmt.Errorf("web adapter: source URL %q resolves to a blocked host", src.URL)
 	}
 
@@ -74,8 +77,8 @@ func (a *WebAdapter) Crawl(ctx context.Context, src config.SourceConfig, sourceI
 			slog.Warn("web: skipping cross-origin sitemap URL", "url", u, "base", src.URL)
 			continue
 		}
-		if !filterURL(parsed, base, filterPath) {
-			if !isAllowedHost(parsed) {
+		if !filterURL(ctx, parsed, base, filterPath) {
+			if !isAllowedHost(ctx, parsed) {
 				slog.Warn("web: skipping blocked host in sitemap URL", "url", u)
 			}
 			continue
@@ -235,65 +238,20 @@ func sameOrigin(u, base *url.URL) bool {
 // filterURL returns true if u should be included in a crawl whose filter
 // path is filterPath and base origin is base. It checks origin, path prefix,
 // and SSRF safety.
-func filterURL(u *url.URL, base *url.URL, filterPath string) bool {
+func filterURL(ctx context.Context, u *url.URL, base *url.URL, filterPath string) bool {
 	if !sameOrigin(u, base) {
 		return false
 	}
 	if !strings.HasPrefix(u.Path, filterPath) && u.Path != strings.TrimRight(filterPath, "/") {
 		return false
 	}
-	if !isAllowedHost(u) {
+	if !isAllowedHost(ctx, u) {
 		return false
 	}
 	return true
 }
 
-// isAllowedHost returns false if the URL's host is a loopback, link-local,
-// or RFC-1918 private address — blocking SSRF via the crawler.
-func isAllowedHost(u *url.URL) bool {
-	host := u.Hostname()
-	if host == "" {
-		return false
-	}
-	// Block well-known internal hostnames.
-	lower := strings.ToLower(host)
-	if lower == "localhost" || strings.HasSuffix(lower, ".local") || strings.HasSuffix(lower, ".internal") {
-		return false
-	}
-	ip := net.ParseIP(host)
-	if ip == nil {
-		// Hostname — allow (full DNS resolution not feasible here).
-		return true
-	}
-	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
-		return false
-	}
-	for _, cidr := range privateRanges {
-		if cidr.Contains(ip) {
-			return false
-		}
-	}
-	return true
+// isAllowedHost delegates to httpsafe.AllowedHost.
+func isAllowedHost(ctx context.Context, u *url.URL) bool {
+	return httpsafe.AllowedHost(ctx, u)
 }
-
-// privateRanges lists CIDR blocks that must not be reachable via the crawler.
-var privateRanges = func() []*net.IPNet {
-	cidrs := []string{
-		"10.0.0.0/8",
-		"172.16.0.0/12",
-		"192.168.0.0/16",
-		"100.64.0.0/10",  // Carrier-grade NAT (RFC 6598)
-		"169.254.0.0/16", // IPv4 link-local
-		"::1/128",        // IPv6 loopback
-		"fc00::/7",       // IPv6 unique local
-		"fe80::/10",      // IPv6 link-local
-	}
-	ranges := make([]*net.IPNet, 0, len(cidrs))
-	for _, cidr := range cidrs {
-		_, network, err := net.ParseCIDR(cidr)
-		if err == nil {
-			ranges = append(ranges, network)
-		}
-	}
-	return ranges
-}()

--- a/internal/adapter/web/web_test.go
+++ b/internal/adapter/web/web_test.go
@@ -2,11 +2,28 @@ package web
 
 import (
 	"context"
+	"net"
 	"net/url"
 	"testing"
 
 	"github.com/mathwro/DocuMcp/internal/config"
+	"github.com/mathwro/DocuMcp/internal/httpsafe"
 )
+
+// withLookup swaps the resolver on the shared httpsafe package for the
+// duration of the test. It lives here so the web-level filterURL tests
+// can still stub DNS; the deeper coverage is in internal/httpsafe.
+func withLookup(t *testing.T, ips map[string][]net.IP) {
+	t.Helper()
+	original := httpsafe.LookupHostIPs
+	httpsafe.LookupHostIPs = func(_ context.Context, host string) ([]net.IP, error) {
+		if v, ok := ips[host]; ok {
+			return v, nil
+		}
+		return nil, &net.DNSError{Err: "no such host", Name: host, IsNotFound: true}
+	}
+	t.Cleanup(func() { httpsafe.LookupHostIPs = original })
+}
 
 func TestCrawl_IncludePath_InvalidURL(t *testing.T) {
 	a := &WebAdapter{}
@@ -33,6 +50,10 @@ func TestCrawl_IncludePath_CrossOrigin(t *testing.T) {
 }
 
 func TestFilterURL_IncludePathFiltersCorrectly(t *testing.T) {
+	withLookup(t, map[string][]net.IP{
+		"docs.example.com": {net.ParseIP("1.2.3.4")},
+		"other.com":        {net.ParseIP("5.6.7.8")},
+	})
 	base := mustParseURL("https://docs.example.com/docs/")
 	filterPath := "/docs/guide/"
 
@@ -50,7 +71,7 @@ func TestFilterURL_IncludePathFiltersCorrectly(t *testing.T) {
 
 	for _, tc := range cases {
 		u := mustParseURL(tc.rawURL)
-		got := filterURL(u, base, filterPath)
+		got := filterURL(context.Background(), u, base, filterPath)
 		if got != tc.want {
 			t.Errorf("filterURL(%q, base, %q) = %v, want %v", tc.rawURL, filterPath, got, tc.want)
 		}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/mathwro/DocuMcp/internal/auth"
@@ -35,6 +37,46 @@ func writeError(w http.ResponseWriter, status int, msg string) {
 func internalError(w http.ResponseWriter, op string, err error) {
 	slog.Error(op, "err", err)
 	writeError(w, http.StatusInternalServerError, "internal server error")
+}
+
+// validateHTTPURL returns an error if raw is not a syntactically valid
+// http(s):// URL with a non-empty host. The field name is used for error
+// messages only.
+func validateHTTPURL(raw, field string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("%s: parse %q: %w", field, raw, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("%s: scheme must be http or https, got %q", field, u.Scheme)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("%s: host is required", field)
+	}
+	return nil
+}
+
+// validateSourceURLs enforces that every URL field on src is http(s) with a host.
+// Empty URLs are allowed for source types that don't require them.
+func validateSourceURLs(src db.Source) error {
+	if src.URL != "" {
+		if err := validateHTTPURL(src.URL, "url"); err != nil {
+			return err
+		}
+	}
+	if src.BaseURL != "" {
+		if err := validateHTTPURL(src.BaseURL, "base_url"); err != nil {
+			return err
+		}
+	}
+	if src.IncludePath != "" && strings.Contains(src.IncludePath, "://") {
+		// IncludePath is a URL for web sources; for github_repo it's a bare subpath.
+		// If it looks like a URL, validate the scheme.
+		if err := validateHTTPURL(src.IncludePath, "include_path"); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // parseID reads the path parameter named "id" and returns it as int64.
@@ -81,6 +123,11 @@ func (s *Server) createSource(w http.ResponseWriter, r *http.Request) {
 	var src db.Source
 	if err := json.NewDecoder(r.Body).Decode(&src); err != nil {
 		writeError(w, http.StatusBadRequest, fmt.Errorf("decode body: %w", err).Error())
+		return
+	}
+
+	if err := validateSourceURLs(src); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -110,6 +110,55 @@ func TestCreateSource(t *testing.T) {
 	}
 }
 
+func TestCreateSource_RejectsDangerousSchemes(t *testing.T) {
+	cases := []struct {
+		name string
+		src  db.Source
+	}{
+		{"file scheme", db.Source{Name: "f", Type: "web", URL: "file:///etc/passwd"}},
+		{"javascript scheme", db.Source{Name: "j", Type: "web", URL: "javascript:alert(1)"}},
+		{"gopher scheme", db.Source{Name: "g", Type: "web", URL: "gopher://evil.example.com/"}},
+		{"ftp scheme", db.Source{Name: "f", Type: "web", URL: "ftp://files.example.com/"}},
+		{"http empty host", db.Source{Name: "e", Type: "web", URL: "http:///path"}},
+		{"bare string", db.Source{Name: "b", Type: "web", URL: "not-a-url"}},
+		{"azure devops bad base_url", db.Source{Name: "a", Type: "azure_devops", URL: "https://dev.azure.com/org", BaseURL: "javascript:alert(1)"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := openTestStore(t)
+			srv := api.NewServer(store, nil, nil, make([]byte, 32))
+			body, err := json.Marshal(tc.src)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			r := httptest.NewRequest(http.MethodPost, "/api/sources", bytes.NewReader(body))
+			r.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			srv.ServeHTTP(w, r)
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("expected 400, got %d: %s", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestCreateSource_AllowsEmptyURLForGitHubTypes(t *testing.T) {
+	// github_wiki and github_repo use the `repo` field, not URL.
+	for _, srcType := range []string{"github_wiki", "github_repo"} {
+		t.Run(srcType, func(t *testing.T) {
+			store := openTestStore(t)
+			srv := api.NewServer(store, nil, nil, make([]byte, 32))
+			body, _ := json.Marshal(db.Source{Name: "g", Type: srcType, Repo: "owner/repo"})
+			r := httptest.NewRequest(http.MethodPost, "/api/sources", bytes.NewReader(body))
+			w := httptest.NewRecorder()
+			srv.ServeHTTP(w, r)
+			if w.Code != http.StatusCreated {
+				t.Errorf("expected 201, got %d: %s", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
 func TestCreateSource_BadBody(t *testing.T) {
 	store := openTestStore(t)
 	srv := api.NewServer(store, nil, nil, make([]byte, 32))

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"log/slog"
 	"net"
@@ -97,8 +98,8 @@ func apiKeyMiddleware(apiKey string, next http.Handler) http.Handler {
 		if apiKey != "" {
 			path := r.URL.Path
 			if strings.HasPrefix(path, "/api/") || strings.HasPrefix(path, "/mcp/") {
-				got := r.Header.Get("Authorization")
-				if got != "Bearer "+apiKey {
+				got := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+				if subtle.ConstantTimeCompare([]byte(got), []byte(apiKey)) != 1 {
 					w.Header().Set("Content-Type", "application/json")
 					w.WriteHeader(http.StatusUnauthorized)
 					json.NewEncoder(w).Encode(map[string]string{"error": "unauthorized"}) //nolint:errcheck

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1,0 +1,101 @@
+package api_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mathwro/DocuMcp/internal/api"
+)
+
+func TestAPIKeyMiddleware_ValidKey(t *testing.T) {
+	t.Setenv("DOCUMCP_API_KEY", "correct-horse-battery-staple")
+	store := openTestStore(t)
+	srv := api.NewServer(store, nil, nil, make([]byte, 32))
+
+	r := httptest.NewRequest(http.MethodGet, "/api/sources", nil)
+	r.Header.Set("Authorization", "Bearer correct-horse-battery-staple")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAPIKeyMiddleware_RejectsWrongKey_SameLength(t *testing.T) {
+	// Same length as the real key — this is the case a timing-unsafe compare
+	// would leak. The regression guard is that we still reject, with no
+	// observable difference from a length-mismatched reject.
+	t.Setenv("DOCUMCP_API_KEY", "correct-horse-battery-staple")
+	store := openTestStore(t)
+	srv := api.NewServer(store, nil, nil, make([]byte, 32))
+
+	r := httptest.NewRequest(http.MethodGet, "/api/sources", nil)
+	r.Header.Set("Authorization", "Bearer incorrect-horse-battery-stap")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAPIKeyMiddleware_RejectsWrongKey_DifferentLength(t *testing.T) {
+	t.Setenv("DOCUMCP_API_KEY", "correct-horse-battery-staple")
+	store := openTestStore(t)
+	srv := api.NewServer(store, nil, nil, make([]byte, 32))
+
+	r := httptest.NewRequest(http.MethodGet, "/api/sources", nil)
+	r.Header.Set("Authorization", "Bearer short")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAPIKeyMiddleware_MissingHeader(t *testing.T) {
+	t.Setenv("DOCUMCP_API_KEY", "correct-horse-battery-staple")
+	store := openTestStore(t)
+	srv := api.NewServer(store, nil, nil, make([]byte, 32))
+
+	r := httptest.NewRequest(http.MethodGet, "/api/sources", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAPIKeyMiddleware_OpenAccessWhenUnset(t *testing.T) {
+	t.Setenv("DOCUMCP_API_KEY", "")
+	store := openTestStore(t)
+	srv := api.NewServer(store, nil, nil, make([]byte, 32))
+
+	r := httptest.NewRequest(http.MethodGet, "/api/sources", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAPIKeyMiddleware_StaticFilesOpen(t *testing.T) {
+	// Web UI assets must be reachable without Authorization even when an API
+	// key is configured. (They cannot send a Bearer header and must still load.)
+	t.Setenv("DOCUMCP_API_KEY", "correct-horse-battery-staple")
+	store := openTestStore(t)
+	srv := api.NewServer(store, nil, nil, make([]byte, 32))
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	if w.Code == http.StatusUnauthorized {
+		t.Errorf("static file handler should not require auth; got 401")
+	}
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -35,7 +35,7 @@ type Source struct {
 	Branch        string
 	BaseURL       string
 	SpaceKey      string
-	Auth          string
+	Auth          string `json:"-"`
 	CrawlSchedule string
 	LastCrawled   *time.Time
 	PageCount     int

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1,12 +1,28 @@
 package db_test
 
 import (
+	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/mathwro/DocuMcp/internal/db"
 )
+
+func TestSource_MarshalJSON_OmitsAuthToken(t *testing.T) {
+	src := db.Source{ID: 1, Name: "s", Type: "github_repo", Auth: "ghp_supersecrettoken"}
+	b, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	if strings.Contains(string(b), "ghp_supersecrettoken") {
+		t.Errorf("Auth token leaked into JSON: %s", b)
+	}
+	if strings.Contains(string(b), `"Auth"`) {
+		t.Errorf("Auth field key present in JSON: %s", b)
+	}
+}
 
 func TestOpen_CreatesSchema(t *testing.T) {
 	store, err := db.Open(":memory:")

--- a/internal/httpsafe/httpsafe.go
+++ b/internal/httpsafe/httpsafe.go
@@ -1,0 +1,108 @@
+// Package httpsafe provides SSRF-safe HTTP helpers for the adapters.
+// It centralises the host-allowlist check and a CheckRedirect hook so
+// every crawl client applies the same policy.
+package httpsafe
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// LookupHostIPs is overridable for tests. Production calls resolve via
+// net.DefaultResolver.
+var LookupHostIPs = func(ctx context.Context, host string) ([]net.IP, error) {
+	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]net.IP, len(addrs))
+	for i, a := range addrs {
+		out[i] = a.IP
+	}
+	return out, nil
+}
+
+// AllowedHost reports whether u's host is safe to connect to. Hostnames
+// are resolved and every returned IP is checked against the blocklist
+// (loopback, link-local, RFC1918, carrier-grade NAT, cloud-metadata
+// ranges, IPv6 unique-local). Unresolvable hosts fail closed.
+func AllowedHost(ctx context.Context, u *url.URL) bool {
+	host := u.Hostname()
+	if host == "" {
+		return false
+	}
+	lower := strings.ToLower(host)
+	if lower == "localhost" || strings.HasSuffix(lower, ".local") || strings.HasSuffix(lower, ".internal") {
+		return false
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return !BlockedIP(ip)
+	}
+	ips, err := LookupHostIPs(ctx, host)
+	if err != nil || len(ips) == 0 {
+		return false
+	}
+	for _, ip := range ips {
+		if BlockedIP(ip) {
+			return false
+		}
+	}
+	return true
+}
+
+// BlockedIP reports whether ip belongs to a range the crawler must not
+// contact (loopback, link-local, RFC1918, CGNAT, cloud-metadata, IPv6
+// unique-local or link-local).
+func BlockedIP(ip net.IP) bool {
+	if ip == nil {
+		return true
+	}
+	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+		ip.IsUnspecified() || ip.IsMulticast() {
+		return true
+	}
+	for _, cidr := range privateRanges {
+		if cidr.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// CheckRedirect is an http.Client.CheckRedirect hook that aborts the
+// chain when the next target resolves to a blocked host, and caps the
+// hop count at 10.
+func CheckRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= 10 {
+		return fmt.Errorf("stopped after 10 redirects")
+	}
+	if !AllowedHost(req.Context(), req.URL) {
+		return fmt.Errorf("redirect to blocked host %q", req.URL.Host)
+	}
+	return nil
+}
+
+var privateRanges = func() []*net.IPNet {
+	cidrs := []string{
+		"10.0.0.0/8",
+		"172.16.0.0/12",
+		"192.168.0.0/16",
+		"100.64.0.0/10",  // Carrier-grade NAT (RFC 6598)
+		"169.254.0.0/16", // IPv4 link-local (includes 169.254.169.254 metadata)
+		"::1/128",        // IPv6 loopback
+		"fc00::/7",       // IPv6 ULA (includes fd00:ec2::254 AWS metadata)
+		"fe80::/10",      // IPv6 link-local
+	}
+	out := make([]*net.IPNet, 0, len(cidrs))
+	for _, c := range cidrs {
+		_, network, err := net.ParseCIDR(c)
+		if err == nil {
+			out = append(out, network)
+		}
+	}
+	return out
+}()

--- a/internal/httpsafe/httpsafe_test.go
+++ b/internal/httpsafe/httpsafe_test.go
@@ -1,0 +1,155 @@
+package httpsafe_test
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/mathwro/DocuMcp/internal/httpsafe"
+)
+
+func withLookup(t *testing.T, ips map[string][]net.IP) {
+	t.Helper()
+	original := httpsafe.LookupHostIPs
+	httpsafe.LookupHostIPs = func(_ context.Context, host string) ([]net.IP, error) {
+		if v, ok := ips[host]; ok {
+			return v, nil
+		}
+		return nil, &net.DNSError{Err: "no such host", Name: host, IsNotFound: true}
+	}
+	t.Cleanup(func() { httpsafe.LookupHostIPs = original })
+}
+
+func TestAllowedHost_IPLiterals(t *testing.T) {
+	cases := []struct {
+		host  string
+		allow bool
+	}{
+		{"1.1.1.1", true},
+		{"127.0.0.1", false},
+		{"10.0.0.5", false},
+		{"192.168.1.1", false},
+		{"169.254.169.254", false},
+		{"::1", false},
+		{"fe80::1", false},
+		{"fc00::1", false},
+		{"fd00:ec2::254", false},
+		{"2001:4860:4860::8888", true},
+	}
+	for _, tc := range cases {
+		var raw string
+		if ip := net.ParseIP(tc.host); ip != nil && ip.To4() == nil {
+			raw = "http://[" + tc.host + "]"
+		} else {
+			raw = "http://" + tc.host
+		}
+		u, err := url.Parse(raw)
+		if err != nil {
+			t.Fatalf("parse %q: %v", raw, err)
+		}
+		if got := httpsafe.AllowedHost(context.Background(), u); got != tc.allow {
+			t.Errorf("AllowedHost(%q) = %v, want %v", tc.host, got, tc.allow)
+		}
+	}
+}
+
+func TestAllowedHost_HostnameResolvingToPrivate(t *testing.T) {
+	withLookup(t, map[string][]net.IP{
+		"evil.example.com": {net.ParseIP("127.0.0.1")},
+	})
+	u, _ := url.Parse("http://evil.example.com/")
+	if httpsafe.AllowedHost(context.Background(), u) {
+		t.Errorf("hostname resolving to 127.0.0.1 must be blocked")
+	}
+}
+
+func TestAllowedHost_HostnameResolvingToMetadata(t *testing.T) {
+	withLookup(t, map[string][]net.IP{
+		"metadata.example.com": {net.ParseIP("169.254.169.254")},
+	})
+	u, _ := url.Parse("http://metadata.example.com/")
+	if httpsafe.AllowedHost(context.Background(), u) {
+		t.Errorf("hostname resolving to 169.254.169.254 must be blocked")
+	}
+}
+
+func TestAllowedHost_HostnameResolvingToPublic(t *testing.T) {
+	withLookup(t, map[string][]net.IP{
+		"ok.example.com": {net.ParseIP("1.2.3.4")},
+	})
+	u, _ := url.Parse("http://ok.example.com/")
+	if !httpsafe.AllowedHost(context.Background(), u) {
+		t.Errorf("hostname resolving to public IP must be allowed")
+	}
+}
+
+func TestAllowedHost_AnyResolvedIPBlockedRejectsHost(t *testing.T) {
+	withLookup(t, map[string][]net.IP{
+		"mixed.example.com": {
+			net.ParseIP("1.2.3.4"),
+			net.ParseIP("127.0.0.1"),
+		},
+	})
+	u, _ := url.Parse("http://mixed.example.com/")
+	if httpsafe.AllowedHost(context.Background(), u) {
+		t.Errorf("hostname with any private resolved IP must be blocked")
+	}
+}
+
+func TestAllowedHost_UnresolvedHostnameBlocked(t *testing.T) {
+	withLookup(t, map[string][]net.IP{})
+	u, _ := url.Parse("http://nowhere.example.com/")
+	if httpsafe.AllowedHost(context.Background(), u) {
+		t.Errorf("hostname that fails to resolve must be blocked (fail closed)")
+	}
+}
+
+func TestCheckRedirect_AllowsPublicTarget(t *testing.T) {
+	withLookup(t, map[string][]net.IP{
+		"public.example.com": {net.ParseIP("1.2.3.4")},
+	})
+	target, _ := http.NewRequest(http.MethodGet, "https://public.example.com/page", nil)
+	if err := httpsafe.CheckRedirect(target, nil); err != nil {
+		t.Errorf("unexpected error for public redirect: %v", err)
+	}
+}
+
+func TestCheckRedirect_BlocksLoopbackTarget(t *testing.T) {
+	target, _ := http.NewRequest(http.MethodGet, "http://127.0.0.1/", nil)
+	if err := httpsafe.CheckRedirect(target, nil); err == nil {
+		t.Errorf("expected error when redirecting to 127.0.0.1")
+	}
+}
+
+func TestCheckRedirect_BlocksResolvedPrivateTarget(t *testing.T) {
+	withLookup(t, map[string][]net.IP{
+		"evil.example.com": {net.ParseIP("10.0.0.1")},
+	})
+	target, _ := http.NewRequest(http.MethodGet, "http://evil.example.com/", nil)
+	if err := httpsafe.CheckRedirect(target, nil); err == nil {
+		t.Errorf("expected error when redirecting to RFC1918")
+	}
+}
+
+func TestCheckRedirect_BlocksMetadataTarget(t *testing.T) {
+	target, _ := http.NewRequest(http.MethodGet, "http://169.254.169.254/latest/meta-data/", nil)
+	if err := httpsafe.CheckRedirect(target, nil); err == nil {
+		t.Errorf("expected error when redirecting to cloud-metadata IP")
+	}
+}
+
+func TestCheckRedirect_CapsRedirectCount(t *testing.T) {
+	withLookup(t, map[string][]net.IP{
+		"ok.example.com": {net.ParseIP("1.2.3.4")},
+	})
+	target, _ := http.NewRequest(http.MethodGet, "http://ok.example.com/", nil)
+	via := make([]*http.Request, 11)
+	for i := range via {
+		via[i] = target
+	}
+	if err := httpsafe.CheckRedirect(target, via); err == nil {
+		t.Errorf("expected error when redirect count exceeds limit")
+	}
+}

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -179,6 +179,16 @@ function app() {
       }
     },
 
+    // safeHref returns u only if it is a plain http(s) URL. Anything else
+    // (javascript:, data:, file:, etc.) collapses to "#" so a malicious
+    // source URL cannot execute script via the href binding.
+    safeHref(u) {
+      if (typeof u !== 'string') return '#'
+      const s = u.trim()
+      if (/^https?:\/\//i.test(s)) return s
+      return '#'
+    },
+
     resultTitle(r) {
       if (r.Title) return r.Title
       try {

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -68,7 +68,7 @@
         <h2>Authenticate</h2>
         <p class="muted" style="margin:0.5rem 0">Visit the URL below and enter the code to connect:</p>
         <div class="device-code-box">
-          <p><a :href="deviceCodePending?.verification_uri" target="_blank" x-text="deviceCodePending?.verification_uri" style="color:var(--accent)"></a></p>
+          <p><a :href="safeHref(deviceCodePending?.verification_uri)" target="_blank" rel="noopener noreferrer" x-text="deviceCodePending?.verification_uri" style="color:var(--accent)"></a></p>
           <div class="device-code" x-text="deviceCodePending?.user_code"></div>
         </div>
         <div class="actions" style="margin-top:1rem">
@@ -133,7 +133,7 @@
       <div class="card" x-show="searchResults.length > 0">
         <template x-for="result in searchResults" :key="result.URL">
           <div class="search-result">
-            <a class="result-title" :href="result.URL" target="_blank" rel="noopener noreferrer" x-text="resultTitle(result)"></a>
+            <a class="result-title" :href="safeHref(result.URL)" target="_blank" rel="noopener noreferrer" x-text="resultTitle(result)"></a>
             <div class="result-meta" x-text="result.URL + ' · score: ' + (result.Score || 0).toFixed(4)"></div>
             <div class="result-snippet" x-text="result.Snippet ? result.Snippet.substring(0, 300) : ''"></div>
           </div>


### PR DESCRIPTION
## Summary
- New `internal/httpsafe` package centralizes SSRF defenses (DNS resolution + IP allow-list + redirect re-validation) across all four HTTP clients: web, github_wiki, github_repo, azure_devops.
- Blocks cloud metadata endpoints on both IPv4 (169.254.169.254) and IPv6 (`fd00:ec2::254` via `fc00::/7`); covers CGNAT, link-local, ULA, loopback, and RFC1918 ranges; fails closed on unresolvable hosts.
- Rejects non-http(s) source URLs at the REST boundary and collapses non-http(s) hrefs in the UI (`safeHref`) — closes `javascript:` / `file:` / `data:` attack surface.
- `subtle.ConstantTimeCompare` for the API bearer token; `json:"-"` on `Source.Auth` so tokens no longer leak through `/api/sources`.

## Test plan
- [x] `CGO_ENABLED=1 go test -tags sqlite_fts5 ./...` passes
- [x] `go vet ./...` clean
- [x] New `internal/httpsafe` unit tests cover private IPs, metadata (v4 + v6), public, mixed resolution, unresolvable (fails closed), and redirect hook
- [x] New `internal/api/server_test.go` covers API-key middleware (valid / wrong-same-length / wrong-different-length / missing / unset-open / static-open)
- [x] `TestSource_MarshalJSON_OmitsAuthToken` verifies token JSON omission
- [x] `TestCreateSource_RejectsDangerousSchemes` covers `javascript:`, `file:`, `data:`, `ftp:`
- [ ] Manual: verify `/api/sources` response no longer contains `Auth` field for authenticated source
- [ ] Manual: verify Azure device-code link and search-result links still work with `safeHref`