### PR TITLE
Bind to 127.0.0.1 by default; add DOCUMCP_BIND_ADDR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,12 @@ USER documcp
 
 EXPOSE 8080
 
+# The binary binds to 127.0.0.1 by default to avoid exposing a fresh install on
+# a host's LAN. Inside the container we must bind all interfaces so port
+# forwarding (-p 8080:8080) reaches the process. Override at `docker run` time
+# with -e DOCUMCP_BIND_ADDR=... if a different address/port is needed.
+ENV DOCUMCP_BIND_ADDR=0.0.0.0:8080
+
 # /app/data  — SQLite database and encrypted token store
 # /app/config.yaml — source-of-truth config (mount from host)
 VOLUME ["/app/data", "/app/config.yaml"]

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Open `http://localhost:8080` to manage sources and search.
 | `DOCUMCP_API_KEY` | Bearer token required on `/api/*` and `/mcp/*` endpoints. If unset, all endpoints are unauthenticated (warns at startup). |
 | `DOCUMCP_CONFIG` | Path to config file (default: `config.yaml`) |
 | `DOCUMCP_MODEL_PATH` | Path to the ONNX model directory |
+| `DOCUMCP_BIND_ADDR` | Address to listen on. Defaults to `127.0.0.1:<port>` so a fresh install is not reachable from the network. The Docker image sets this to `0.0.0.0:8080` so the container's port mapping works; when running the binary directly, set `DOCUMCP_BIND_ADDR=0.0.0.0:8080` to expose it on the LAN. |
 
 ## Source Types
 

--- a/cmd/documcp/main.go
+++ b/cmd/documcp/main.go
@@ -76,7 +76,7 @@ func main() {
 	// Warn if no API key is configured — the API and MCP endpoints are open.
 	api.LogAPIKeyWarning()
 
-	addr := fmt.Sprintf(":%d", cfg.Server.Port)
+	addr := bindAddr(cfg.Server.Port)
 	slog.Info("starting DocuMcp", "addr", addr)
 
 	srv := &http.Server{
@@ -154,4 +154,15 @@ func getenv(key, def string) string {
 		return v
 	}
 	return def
+}
+
+// bindAddr returns the address to listen on. DOCUMCP_BIND_ADDR takes
+// precedence (e.g. "0.0.0.0:8080" in containers). Otherwise the server
+// binds to loopback on the configured port so a default install is not
+// reachable from the network. Set DOCUMCP_BIND_ADDR to expose it.
+func bindAddr(port int) string {
+	if v := os.Getenv("DOCUMCP_BIND_ADDR"); v != "" {
+		return v
+	}
+	return fmt.Sprintf("127.0.0.1:%d", port)
 }

--- a/cmd/documcp/main_test.go
+++ b/cmd/documcp/main_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestBindAddr_DefaultsToLoopback(t *testing.T) {
+	t.Setenv("DOCUMCP_BIND_ADDR", "")
+	got := bindAddr(8080)
+	if got != "127.0.0.1:8080" {
+		t.Fatalf("bindAddr(8080) = %q, want 127.0.0.1:8080", got)
+	}
+}
+
+func TestBindAddr_EnvOverride(t *testing.T) {
+	t.Setenv("DOCUMCP_BIND_ADDR", "0.0.0.0:9090")
+	got := bindAddr(8080)
+	if got != "0.0.0.0:9090" {
+		t.Fatalf("bindAddr with override = %q, want 0.0.0.0:9090", got)
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,10 @@ services:
       # Optional: bearer token required on /api/* and /mcp/* endpoints.
       # If empty, those endpoints are open (warns at startup).
       - DOCUMCP_API_KEY=${DOCUMCP_API_KEY:-}
+      # Optional: override the address the server binds to. The image sets
+      # 0.0.0.0:8080 so the compose port mapping works; only set this if you
+      # need a different port.
+      # - DOCUMCP_BIND_ADDR=0.0.0.0:8080
 
 volumes:
   documcp_data:


### PR DESCRIPTION
## Summary
- Bare-binary installs now listen on `127.0.0.1:<port>` instead of `:8080`, so a `go run` / released binary does not expose the admin UI and MCP endpoints on the host's LAN without opt-in.
- `DOCUMCP_BIND_ADDR` overrides the default (e.g. `0.0.0.0:8080`, `192.168.1.10:9000`).
- Dockerfile sets `ENV DOCUMCP_BIND_ADDR=0.0.0.0:8080` so the container's `-p 8080:8080` port mapping continues to work unchanged.

## Test plan
- [x] `CGO_ENABLED=1 go test -tags sqlite_fts5 ./...` passes
- [x] New unit tests cover default (no env) and env-override cases
- [ ] Manual: `documcp` on host — verify UI reachable on `127.0.0.1:8080`, not reachable on LAN IP
- [ ] Manual: `docker run -p 8080:8080 documcp:local` — verify UI reachable via host port mapping
- [ ] Manual: `DOCUMCP_BIND_ADDR=0.0.0.0:8080 documcp` — verify LAN reachability