### PR TITLE
CI workflow, module path fix, version-tag image publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26.x'
+          cache: true
+
+      - name: Install libsqlite3-dev
+        run: sudo apt-get update && sudo apt-get install -y libsqlite3-dev
+
+      - name: gofmt
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "The following files are not gofmt-clean:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      - name: go vet
+        env:
+          CGO_ENABLED: '1'
+        run: go vet -tags sqlite_fts5 ./...
+
+      - name: go build
+        env:
+          CGO_ENABLED: '1'
+        run: go build -tags sqlite_fts5 ./...
+
+      - name: go test
+        env:
+          CGO_ENABLED: '1'
+        run: go test -tags sqlite_fts5 -race ./...

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,12 +12,8 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+    # Skip on forks — avoids spending another account's Claude quota on fork PRs.
+    if: github.repository == 'mathwro/DocuMcp'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,14 @@ on:
 
 jobs:
   claude:
+    # Skip on forks — avoids spending another account's Claude quota on fork PRs.
     if: |
+      github.repository == 'mathwro/DocuMcp' && (
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,6 +1,9 @@
 name: Publish Container Image
 
 on:
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
 
 env:
@@ -30,10 +33,15 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # Publish version tags (v1.2.3 → 1.2.3, 1.2, 1), the commit SHA,
+          # and `latest` when pushing a version tag. Manual workflow_dispatch
+          # runs from main still get a commit-SHA tag.
           tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
             type=sha
-            type=ref,event=branch
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/cmd/documcp/main.go
+++ b/cmd/documcp/main.go
@@ -13,13 +13,13 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/documcp/documcp/internal/api"
-	"github.com/documcp/documcp/internal/auth"
-	"github.com/documcp/documcp/internal/config"
-	"github.com/documcp/documcp/internal/crawler"
-	"github.com/documcp/documcp/internal/db"
-	"github.com/documcp/documcp/internal/embed"
-	"github.com/documcp/documcp/internal/mcp"
+	"github.com/mathwro/DocuMcp/internal/api"
+	"github.com/mathwro/DocuMcp/internal/auth"
+	"github.com/mathwro/DocuMcp/internal/config"
+	"github.com/mathwro/DocuMcp/internal/crawler"
+	"github.com/mathwro/DocuMcp/internal/db"
+	"github.com/mathwro/DocuMcp/internal/embed"
+	"github.com/mathwro/DocuMcp/internal/mcp"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/documcp/documcp
+module github.com/mathwro/DocuMcp
 
 go 1.26.0
 

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -3,8 +3,8 @@ package adapter
 import (
 	"context"
 
-	"github.com/documcp/documcp/internal/config"
-	"github.com/documcp/documcp/internal/db"
+	"github.com/mathwro/DocuMcp/internal/config"
+	"github.com/mathwro/DocuMcp/internal/db"
 )
 
 // Adapter is implemented by each documentation source type.

--- a/internal/adapter/azuredevops/azuredevops.go
+++ b/internal/adapter/azuredevops/azuredevops.go
@@ -9,9 +9,9 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/documcp/documcp/internal/adapter"
-	"github.com/documcp/documcp/internal/config"
-	"github.com/documcp/documcp/internal/db"
+	"github.com/mathwro/DocuMcp/internal/adapter"
+	"github.com/mathwro/DocuMcp/internal/config"
+	"github.com/mathwro/DocuMcp/internal/db"
 )
 
 func init() {

--- a/internal/adapter/azuredevops/azuredevops_test.go
+++ b/internal/adapter/azuredevops/azuredevops_test.go
@@ -7,8 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/documcp/documcp/internal/adapter/azuredevops"
-	"github.com/documcp/documcp/internal/config"
+	"github.com/mathwro/DocuMcp/internal/adapter/azuredevops"
+	"github.com/mathwro/DocuMcp/internal/config"
 )
 
 func TestAzureDevOpsAdapter_CrawlsWikiPages(t *testing.T) {

--- a/internal/adapter/github/github.go
+++ b/internal/adapter/github/github.go
@@ -9,9 +9,9 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/documcp/documcp/internal/adapter"
-	"github.com/documcp/documcp/internal/config"
-	"github.com/documcp/documcp/internal/db"
+	"github.com/mathwro/DocuMcp/internal/adapter"
+	"github.com/mathwro/DocuMcp/internal/config"
+	"github.com/mathwro/DocuMcp/internal/db"
 )
 
 func init() {

--- a/internal/adapter/github/github_test.go
+++ b/internal/adapter/github/github_test.go
@@ -8,8 +8,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/documcp/documcp/internal/adapter/github"
-	"github.com/documcp/documcp/internal/config"
+	"github.com/mathwro/DocuMcp/internal/adapter/github"
+	"github.com/mathwro/DocuMcp/internal/config"
 )
 
 func TestGitHubAdapter_CrawlsWikiPages(t *testing.T) {

--- a/internal/adapter/githubrepo/githubrepo.go
+++ b/internal/adapter/githubrepo/githubrepo.go
@@ -14,9 +14,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/documcp/documcp/internal/adapter"
-	"github.com/documcp/documcp/internal/config"
-	"github.com/documcp/documcp/internal/db"
+	"github.com/mathwro/DocuMcp/internal/adapter"
+	"github.com/mathwro/DocuMcp/internal/config"
+	"github.com/mathwro/DocuMcp/internal/db"
 )
 
 const maxFileSize = 5 * 1024 * 1024 // 5 MiB per file

--- a/internal/adapter/githubrepo/githubrepo_test.go
+++ b/internal/adapter/githubrepo/githubrepo_test.go
@@ -12,11 +12,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/documcp/documcp/internal/adapter"
-	_ "github.com/documcp/documcp/internal/adapter/githubrepo"
-	"github.com/documcp/documcp/internal/adapter/githubrepo"
-	"github.com/documcp/documcp/internal/config"
-	"github.com/documcp/documcp/internal/db"
+	"github.com/mathwro/DocuMcp/internal/adapter"
+	"github.com/mathwro/DocuMcp/internal/adapter/githubrepo"
+	_ "github.com/mathwro/DocuMcp/internal/adapter/githubrepo"
+	"github.com/mathwro/DocuMcp/internal/config"
+	"github.com/mathwro/DocuMcp/internal/db"
 )
 
 func TestAdapterRegistered(t *testing.T) {

--- a/internal/adapter/web/extract_test.go
+++ b/internal/adapter/web/extract_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/documcp/documcp/internal/adapter/web"
+	"github.com/mathwro/DocuMcp/internal/adapter/web"
 )
 
 func TestExtractText_RemovesNavAndScript(t *testing.T) {

--- a/internal/adapter/web/sitemap_test.go
+++ b/internal/adapter/web/sitemap_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/documcp/documcp/internal/adapter/web"
+	"github.com/mathwro/DocuMcp/internal/adapter/web"
 )
 
 func TestParseSitemap(t *testing.T) {

--- a/internal/adapter/web/web.go
+++ b/internal/adapter/web/web.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/documcp/documcp/internal/adapter"
-	"github.com/documcp/documcp/internal/config"
-	"github.com/documcp/documcp/internal/db"
+	"github.com/mathwro/DocuMcp/internal/adapter"
+	"github.com/mathwro/DocuMcp/internal/config"
+	"github.com/mathwro/DocuMcp/internal/db"
 )
 
 func init() {
@@ -125,7 +125,7 @@ func (a *WebAdapter) Crawl(ctx context.Context, src config.SourceConfig, sourceI
 	return total, ch, nil
 }
 
-const crawlUserAgent = "DocuMcp/1.0 (documentation indexer; +https://github.com/documcp/documcp)"
+const crawlUserAgent = "DocuMcp/1.0 (documentation indexer; +https://github.com/mathwro/DocuMcp)"
 
 func fetchPage(ctx context.Context, client *http.Client, pageURL string, sourceID int64, base *url.URL) (db.Page, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", pageURL, nil)
@@ -282,7 +282,7 @@ var privateRanges = func() []*net.IPNet {
 		"10.0.0.0/8",
 		"172.16.0.0/12",
 		"192.168.0.0/16",
-		"100.64.0.0/10", // Carrier-grade NAT (RFC 6598)
+		"100.64.0.0/10",  // Carrier-grade NAT (RFC 6598)
 		"169.254.0.0/16", // IPv4 link-local
 		"::1/128",        // IPv6 loopback
 		"fc00::/7",       // IPv6 unique local

--- a/internal/adapter/web/web_test.go
+++ b/internal/adapter/web/web_test.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/documcp/documcp/internal/config"
+	"github.com/mathwro/DocuMcp/internal/config"
 )
 
 func TestCrawl_IncludePath_InvalidURL(t *testing.T) {
@@ -42,10 +42,10 @@ func TestFilterURL_IncludePathFiltersCorrectly(t *testing.T) {
 	}{
 		{"https://docs.example.com/docs/guide/page1", true},
 		{"https://docs.example.com/docs/guide/", true},
-		{"https://docs.example.com/docs/guide", true}, // exact path without trailing slash
-		{"https://docs.example.com/docs/api/page2", false},  // wrong section
-		{"https://docs.example.com/docs/", false},           // parent path
-		{"https://other.com/docs/guide/page1", false},       // cross-origin
+		{"https://docs.example.com/docs/guide", true},      // exact path without trailing slash
+		{"https://docs.example.com/docs/api/page2", false}, // wrong section
+		{"https://docs.example.com/docs/", false},          // parent path
+		{"https://other.com/docs/guide/page1", false},      // cross-origin
 	}
 
 	for _, tc := range cases {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -10,9 +10,9 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/documcp/documcp/internal/auth"
-	"github.com/documcp/documcp/internal/db"
-	"github.com/documcp/documcp/internal/search"
+	"github.com/mathwro/DocuMcp/internal/auth"
+	"github.com/mathwro/DocuMcp/internal/db"
+	"github.com/mathwro/DocuMcp/internal/search"
 )
 
 // writeJSON writes v as JSON to w with the given status code.

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -8,9 +8,9 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/documcp/documcp/internal/api"
-	"github.com/documcp/documcp/internal/auth"
-	"github.com/documcp/documcp/internal/db"
+	"github.com/mathwro/DocuMcp/internal/api"
+	"github.com/mathwro/DocuMcp/internal/auth"
+	"github.com/mathwro/DocuMcp/internal/db"
 )
 
 func openTestStore(t *testing.T) *db.Store {
@@ -534,4 +534,3 @@ func TestAuthSetToken_RejectsNonGitHub(t *testing.T) {
 		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
 	}
 }
-

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -10,10 +10,10 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/documcp/documcp/internal/auth"
-	"github.com/documcp/documcp/internal/crawler"
-	"github.com/documcp/documcp/internal/db"
-	"github.com/documcp/documcp/web"
+	"github.com/mathwro/DocuMcp/internal/auth"
+	"github.com/mathwro/DocuMcp/internal/crawler"
+	"github.com/mathwro/DocuMcp/internal/db"
+	"github.com/mathwro/DocuMcp/web"
 )
 
 // pendingFlow holds an in-progress Microsoft device-code flow.

--- a/internal/auth/microsoft_test.go
+++ b/internal/auth/microsoft_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/documcp/documcp/internal/auth"
+	"github.com/mathwro/DocuMcp/internal/auth"
 )
 
 func TestMicrosoftDeviceFlow_InitiatesSuccessfully(t *testing.T) {

--- a/internal/auth/store.go
+++ b/internal/auth/store.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/documcp/documcp/internal/db"
+	"github.com/mathwro/DocuMcp/internal/db"
 )
 
 // TokenStore encrypts and stores OAuth tokens in SQLite using AES-256-GCM.

--- a/internal/auth/store_test.go
+++ b/internal/auth/store_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/documcp/documcp/internal/auth"
-	"github.com/documcp/documcp/internal/db"
+	"github.com/mathwro/DocuMcp/internal/auth"
+	"github.com/mathwro/DocuMcp/internal/db"
 )
 
 func TestTokenStore_SaveAndLoad(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,7 +26,7 @@ type SourceConfig struct {
 	// web
 	URL         string `yaml:"url,omitempty"`
 	IncludePath string `yaml:"include_path,omitempty"`
-	Auth string `yaml:"auth,omitempty"`
+	Auth        string `yaml:"auth,omitempty"`
 	// confluence
 	BaseURL  string `yaml:"base_url,omitempty"`
 	SpaceKey string `yaml:"space_key,omitempty"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/documcp/documcp/internal/config"
+	"github.com/mathwro/DocuMcp/internal/config"
 )
 
 func TestLoadConfig_ValidFile(t *testing.T) {

--- a/internal/config/watcher_test.go
+++ b/internal/config/watcher_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/documcp/documcp/internal/config"
+	"github.com/mathwro/DocuMcp/internal/config"
 )
 
 func TestWatcher_CallsCallbackOnChange(t *testing.T) {

--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -6,15 +6,15 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/documcp/documcp/internal/adapter"
-	_ "github.com/documcp/documcp/internal/adapter/azuredevops"
-	_ "github.com/documcp/documcp/internal/adapter/github"
-	_ "github.com/documcp/documcp/internal/adapter/githubrepo"
-	_ "github.com/documcp/documcp/internal/adapter/web"
-	"github.com/documcp/documcp/internal/auth"
-	"github.com/documcp/documcp/internal/config"
-	"github.com/documcp/documcp/internal/db"
-	"github.com/documcp/documcp/internal/embed"
+	"github.com/mathwro/DocuMcp/internal/adapter"
+	_ "github.com/mathwro/DocuMcp/internal/adapter/azuredevops"
+	_ "github.com/mathwro/DocuMcp/internal/adapter/github"
+	_ "github.com/mathwro/DocuMcp/internal/adapter/githubrepo"
+	_ "github.com/mathwro/DocuMcp/internal/adapter/web"
+	"github.com/mathwro/DocuMcp/internal/auth"
+	"github.com/mathwro/DocuMcp/internal/config"
+	"github.com/mathwro/DocuMcp/internal/db"
+	"github.com/mathwro/DocuMcp/internal/embed"
 )
 
 // Crawler dispatches crawl jobs to the appropriate adapter, persists pages,

--- a/internal/crawler/crawler_internal_test.go
+++ b/internal/crawler/crawler_internal_test.go
@@ -3,7 +3,7 @@ package crawler
 import (
 	"testing"
 
-	"github.com/documcp/documcp/internal/db"
+	"github.com/mathwro/DocuMcp/internal/db"
 )
 
 func TestSourceToConfig_github_repo_defaults_branch_to_main(t *testing.T) {

--- a/internal/crawler/crawler_test.go
+++ b/internal/crawler/crawler_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/documcp/documcp/internal/adapter"
-	"github.com/documcp/documcp/internal/config"
-	"github.com/documcp/documcp/internal/crawler"
-	"github.com/documcp/documcp/internal/db"
+	"github.com/mathwro/DocuMcp/internal/adapter"
+	"github.com/mathwro/DocuMcp/internal/config"
+	"github.com/mathwro/DocuMcp/internal/crawler"
+	"github.com/mathwro/DocuMcp/internal/db"
 )
 
 // stubAdapter is a test-only adapter that returns a fixed set of pages without

--- a/internal/crawler/scheduler.go
+++ b/internal/crawler/scheduler.go
@@ -5,8 +5,8 @@ import (
 	"log/slog"
 	"sync"
 
-	"github.com/documcp/documcp/internal/config"
-	"github.com/documcp/documcp/internal/db"
+	"github.com/mathwro/DocuMcp/internal/config"
+	"github.com/mathwro/DocuMcp/internal/db"
 	"github.com/robfig/cron/v3"
 )
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/documcp/documcp/internal/db"
+	"github.com/mathwro/DocuMcp/internal/db"
 )
 
 func TestOpen_CreatesSchema(t *testing.T) {

--- a/internal/embed/embedder_test.go
+++ b/internal/embed/embedder_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/documcp/documcp/internal/embed"
+	"github.com/mathwro/DocuMcp/internal/embed"
 )
 
 func TestEmbedder_ProducesVectors(t *testing.T) {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -6,8 +6,8 @@ import (
 
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
-	"github.com/documcp/documcp/internal/db"
-	"github.com/documcp/documcp/internal/embed"
+	"github.com/mathwro/DocuMcp/internal/db"
+	"github.com/mathwro/DocuMcp/internal/embed"
 )
 
 // Server wraps the go-sdk MCP server and holds references to the data layer.

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -9,8 +9,8 @@ import (
 
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
-	"github.com/documcp/documcp/internal/db"
-	mcpserver "github.com/documcp/documcp/internal/mcp"
+	"github.com/mathwro/DocuMcp/internal/db"
+	mcpserver "github.com/mathwro/DocuMcp/internal/mcp"
 )
 
 // openTestDB creates a temporary SQLite database for testing.
@@ -359,4 +359,3 @@ func TestSearchDocs_ResultDTO(t *testing.T) {
 		t.Error("expected 'snippet' field in result")
 	}
 }
-

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -10,8 +10,8 @@ import (
 
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
-	"github.com/documcp/documcp/internal/db"
-	"github.com/documcp/documcp/internal/search"
+	"github.com/mathwro/DocuMcp/internal/db"
+	"github.com/mathwro/DocuMcp/internal/search"
 )
 
 // sourceInfo is the MCP-facing representation of a documentation source.
@@ -66,7 +66,7 @@ var objectSchema = json.RawMessage(`{"type":"object"}`)
 // registerTools adds all four MCP tools to the server.
 func (s *Server) registerTools() {
 	s.server.AddTool(&sdkmcp.Tool{
-		Name:        "list_sources",
+		Name: "list_sources",
 		Description: "List all configured documentation sources with their names, types, URLs, " +
 			"page counts, and last crawl times. Call this first if you do not know what sources " +
 			"are available. Source names are required parameters for search_docs and browse_source.",
@@ -74,7 +74,7 @@ func (s *Server) registerTools() {
 	}, s.handleListSources)
 
 	s.server.AddTool(&sdkmcp.Tool{
-		Name:        "search_docs",
+		Name: "search_docs",
 		Description: "Start here for any documentation question. Searches all indexed sources using " +
 			"hybrid BM25 + semantic search and returns up to 10 results ranked by relevance. Each " +
 			"result includes the source name, section path, and a short excerpt (~200 chars) centred " +
@@ -91,7 +91,7 @@ func (s *Server) registerTools() {
 	}, s.handleSearchDocs)
 
 	s.server.AddTool(&sdkmcp.Tool{
-		Name:        "browse_source",
+		Name: "browse_source",
 		Description: "Explore the structure of a documentation source. Without section: returns all " +
 			"top-level sections with page counts — use this to understand what a source contains. " +
 			"With section: returns up to 50 pages (URL + title) in that section. Prefer search_docs " +
@@ -108,7 +108,7 @@ func (s *Server) registerTools() {
 	}, s.handleBrowseSource)
 
 	s.server.AddTool(&sdkmcp.Tool{
-		Name:        "get_page",
+		Name: "get_page",
 		Description: "Retrieve the full content of a single documentation page by URL. Only call " +
 			"this after confirming relevance — use search_docs first to find candidate URLs and " +
 			"read their excerpts. Returns the complete page text, which may be large for reference " +

--- a/internal/search/browse.go
+++ b/internal/search/browse.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/documcp/documcp/internal/db"
+	"github.com/mathwro/DocuMcp/internal/db"
 )
 
 // browseSectionLimit is the maximum number of pages returned by BrowseSection.

--- a/internal/search/browse_test.go
+++ b/internal/search/browse_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/documcp/documcp/internal/db"
-	"github.com/documcp/documcp/internal/search"
+	"github.com/mathwro/DocuMcp/internal/db"
+	"github.com/mathwro/DocuMcp/internal/search"
 )
 
 func setupBrowseDB(t *testing.T) (*db.Store, int64) {

--- a/internal/search/fts.go
+++ b/internal/search/fts.go
@@ -3,7 +3,7 @@ package search
 import (
 	"fmt"
 
-	"github.com/documcp/documcp/internal/db"
+	"github.com/mathwro/DocuMcp/internal/db"
 )
 
 // FTS performs a full-text search using SQLite FTS5 BM25 ranking.

--- a/internal/search/fts_test.go
+++ b/internal/search/fts_test.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/documcp/documcp/internal/db"
-	"github.com/documcp/documcp/internal/search"
+	"github.com/mathwro/DocuMcp/internal/db"
+	"github.com/mathwro/DocuMcp/internal/search"
 )
 
 func setupTestDB(t *testing.T) *db.Store {

--- a/internal/search/result_test.go
+++ b/internal/search/result_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/documcp/documcp/internal/db"
-	"github.com/documcp/documcp/internal/search"
+	"github.com/mathwro/DocuMcp/internal/db"
+	"github.com/mathwro/DocuMcp/internal/search"
 )
 
 func TestFTS_SnippetMaxLength(t *testing.T) {

--- a/internal/search/rrf_test.go
+++ b/internal/search/rrf_test.go
@@ -3,7 +3,7 @@ package search_test
 import (
 	"testing"
 
-	"github.com/documcp/documcp/internal/search"
+	"github.com/mathwro/DocuMcp/internal/search"
 )
 
 func makeResult(url string, score float64) search.Result {

--- a/internal/search/semantic.go
+++ b/internal/search/semantic.go
@@ -3,8 +3,8 @@ package search
 import (
 	"fmt"
 
-	"github.com/documcp/documcp/internal/db"
-	"github.com/documcp/documcp/internal/embed"
+	"github.com/mathwro/DocuMcp/internal/db"
+	"github.com/mathwro/DocuMcp/internal/embed"
 )
 
 // Semantic runs a nearest-neighbour vector search using sqlite-vec.


### PR DESCRIPTION
## Summary
- Rename module to `github.com/mathwro/DocuMcp` so `go install` / `go get` work against the real repo path. All imports and tests updated; build and tests pass with `-race`.
- Add `.github/workflows/ci.yml` — gofmt check, `go vet`, `go build`, `go test -race`, all with `CGO_ENABLED=1` and `-tags sqlite_fts5`. Runs on push to `main` and every PR.
- `publish-image.yml` now triggers on `push: tags: ['v*']` with semver metadata tags (1.2.3, 1.2, 1, sha, latest on tag push). Keeps `workflow_dispatch` for ad-hoc rebuilds.
- Gate Claude workflows with `github.repository == 'mathwro/DocuMcp'` so forks don't spend another account's Claude quota.
- Ran `gofmt -w .` on the tree (7 pre-existing files) so the new CI step passes on first run.

## Test plan
- [x] Local: `gofmt -l .` clean
- [x] Local: `CGO_ENABLED=1 go vet -tags sqlite_fts5 ./...` clean
- [x] Local: `CGO_ENABLED=1 go test -tags sqlite_fts5 -race ./...` passes
- [ ] CI: first run on this PR should be green
- [ ] Manual: `git tag v0.1.0-test && git push origin v0.1.0-test` → `publish-image` workflow runs and pushes tagged image to ghcr.io; then delete the tag + image to avoid releasing a test version.