### PR TITLE
Docs: SECURITY.md, CONTRIBUTING.md, Claude Code wiring, troubleshooting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,19 @@
+# DocuMcp environment variables. Copy to `.env` for docker-compose.
+# None of these files is read directly by the binary — docker-compose and
+# `make init` set them on the container from this file.
+
+# REQUIRED for persistent encrypted token storage across restarts.
+# Generate with: openssl rand -hex 32
+# If unset, a random key is generated per run and stored tokens (GitHub PATs,
+# Azure DevOps OAuth tokens) are lost when the process restarts.
 DOCUMCP_SECRET_KEY=
+
+# Optional. Bearer token required on /api/* and /mcp/* endpoints.
+# If unset, those endpoints are unauthenticated (a warning is logged at startup).
+# Generate with: openssl rand -hex 32
+# DOCUMCP_API_KEY=
+
+# Optional. Address the HTTP server binds to. Defaults to 127.0.0.1:<port>
+# for bare-binary installs so a fresh install is not exposed on the LAN.
+# The container image pre-sets 0.0.0.0:8080 so the compose port mapping works.
+# DOCUMCP_BIND_ADDR=0.0.0.0:8080

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,8 +21,9 @@ internal/config/    # YAML config + fsnotify file watcher
 internal/db/        # SQLite schema, CRUD, FTS5, tokens, migrations
 internal/search/    # FTS5 + semantic search + RRF + browse
 internal/embed/     # ONNX embedding inference (hugot)
-internal/adapter/   # Adapter interface + web/github/azuredevops impls
-internal/auth/      # Device code flows (Microsoft, GitHub), encrypted token store
+internal/adapter/   # Adapter interface + web/github/githubrepo/azuredevops impls
+internal/auth/      # Microsoft device code flow, encrypted token store
+internal/httpsafe/  # SSRF defenses shared by all HTTP clients
 internal/crawler/   # Crawl orchestrator + cron scheduler
 internal/mcp/       # MCP server — 4 tools via go-sdk SSE
 internal/api/       # REST API handlers + static file serving
@@ -50,9 +51,14 @@ Crawl(ctx context.Context, source config.SourceConfig, sourceID int64) (int, <-c
 // int = total URL count (0 if unknown); channel closed when done
 ```
 
+### HTTP client hardening (SSRF)
+- `internal/httpsafe` centralizes DNS resolution + IP allow-list + redirect re-validation for every source adapter
+- All adapter HTTP clients MUST set `CheckRedirect: httpsafe.CheckRedirect` so a 302 cannot redirect to a private IP
+- `httpsafe.AllowedHost(ctx, *url.URL)` resolves the hostname and fails closed if any resolved IP is private, CGNAT, loopback, link-local, or cloud metadata (IPv4 169.254.169.254, IPv6 `fd00:ec2::254`)
+- Never use `httptest.NewServer` in adapter tests — it binds to loopback which the SSRF check blocks. Use stub adapters and override `httpsafe.LookupHostIPs` when a test needs a specific resolution
+
 ### Web Adapter
-- SSRF protection: `isAllowedHost()` blocks loopback/private IPs — never use `httptest.NewServer` in tests; use stub adapters instead
-- `filterURL(u, base, filterPath)` helper encapsulates origin + path-prefix + SSRF checks
+- `filterURL(ctx, u, base, filterPath)` helper encapsulates origin + path-prefix + SSRF checks
 - `include_path` field: if set, overrides `base.Path` as the URL prefix filter; must share same origin
 - Sitemap discovery: tries `<src>/sitemap.xml` then `<origin>/sitemap.xml`
 - Polite crawling: 500ms delay between pages, User-Agent header, 429/Retry-After backoff
@@ -79,16 +85,19 @@ Crawl(ctx context.Context, source config.SourceConfig, sourceID int64) (int, <-c
 
 ## Architecture
 - **Storage:** SQLite with FTS5 + sqlite-vec; `all-MiniLM-L6-v2` ONNX model bundled in image
-- **Auth:** Device code flows only — no app registrations needed
-  - Microsoft: Azure CLI client ID `04b07795-8ddb-461a-bbee-02f9e1bf7b46`
-  - GitHub: standard device flow
+- **Auth:**
+  - Microsoft (Azure DevOps): device code flow using Azure CLI client ID `04b07795-8ddb-461a-bbee-02f9e1bf7b46`
+  - GitHub (wiki + repo): user-supplied fine-grained PAT via `PUT /api/sources/{id}/auth/token`; public repos work without a token
 - **Tokens:** AES-256-GCM encrypted in SQLite; key from `DOCUMCP_SECRET_KEY` env var
+- **API auth:** optional `DOCUMCP_API_KEY` bearer token on `/api/*` and `/mcp/*`; constant-time compared
+- **Bind address:** defaults to `127.0.0.1:<port>`; override with `DOCUMCP_BIND_ADDR`; the container image pre-sets `0.0.0.0:8080`
 - **MCP:** `github.com/modelcontextprotocol/go-sdk` v0.8.0, SSE transport at `/mcp/`
 - **Container:** multi-stage Dockerfile, non-root user `documcp` (uid 1001), podman-compatible
 
 ## Source Types
 | Type | Auth | Key fields |
 |---|---|---|
-| `web` | none / basic | `url`, `include_path` (optional path-prefix filter) |
-| `github_wiki` | GitHub device code | `repo` (owner/repo) |
+| `web` | none | `url`, `include_path` (optional path-prefix filter, same origin required) |
+| `github_wiki` | fine-grained PAT (optional for public wikis) | `repo` (owner/repo) |
+| `github_repo` | fine-grained PAT (optional for public repos) | `repo`, `branch`, `include_path` (subfolder) |
 | `azure_devops` | Microsoft device code | `url`, `base_url` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,84 @@
+# Contributing to DocuMcp
+
+Thanks for taking the time to contribute! This document covers the
+development loop and what I look for in a pull request.
+
+## Development loop
+
+### Requirements
+
+- Go 1.26+ with CGo enabled
+- GCC and `libsqlite3-dev` (or the equivalent on your distro) — the
+  SQLite FTS5 and sqlite-vec bindings both require CGo
+- `podman` or `docker` if you want to build the container image
+
+### Build and test
+
+```bash
+make build   # CGO_ENABLED=1 go build -tags sqlite_fts5 ./...
+make test    # CGO_ENABLED=1 go test -tags sqlite_fts5 ./...
+```
+
+Both the `CGO_ENABLED=1` and `-tags sqlite_fts5` flags are required for
+every build and test command. If you forget either, the binary will panic
+on first query.
+
+### Run locally against your own config
+
+```bash
+make init              # writes config.yaml and .env with a generated key
+$EDITOR config.yaml    # add a source or two
+DOCUMCP_CONFIG=./config.yaml \
+DOCUMCP_SECRET_KEY="$(grep DOCUMCP_SECRET_KEY .env | cut -d= -f2)" \
+go run -tags sqlite_fts5 ./cmd/documcp
+```
+
+The server binds to `127.0.0.1:8080` by default. Open
+<http://127.0.0.1:8080> to manage sources and drive searches.
+
+## Submitting a pull request
+
+Before opening a PR, please:
+
+- Base the branch on `main` and keep it focused on a single change.
+- Run `gofmt -w .`, `go vet -tags sqlite_fts5 ./...`, and
+  `go test -tags sqlite_fts5 -race ./...` — CI enforces all three.
+- Add tests for new behavior. Integration tests that exercise HTTP
+  handlers should use `httptest` against the in-memory SQLite store, not
+  `httptest.NewServer` for source adapters — the web adapter's SSRF
+  check blocks loopback IPs, so use stub adapters in adapter tests.
+- Write PR descriptions that explain *why* the change is needed and what
+  you tested. A bullet summary and a manual test plan are plenty.
+
+## Code style
+
+- Wrap errors: `fmt.Errorf("context: %w", err)`. Never return a raw
+  error from a package boundary.
+- Return `db.ErrNotFound` for missing rows; callers use `errors.Is`.
+- Return empty slices (`make([]T, 0)`), not `nil`, from list operations.
+- Keep comments terse — explain *why*, not *what*. Remove dead code
+  rather than commenting it out.
+- No `// Added for X` / `// Used by Y` comments; the code speaks for
+  itself and those comments rot.
+
+## Scope I am likely to accept
+
+- Additional source adapters (GitLab Wiki, Confluence, Notion, etc.)
+- Incremental crawling (ETags, Last-Modified)
+- Bug fixes and regression tests
+- Security hardening
+- Documentation improvements
+
+## Scope I am likely to push back on
+
+- Multi-tenant features — DocuMcp is a single-user local service.
+- UI overhauls or framework swaps. The current Alpine.js UI is
+  deliberately minimal.
+- New runtime dependencies (a second database, a message broker, a
+  second embedding model). The single-binary + single-SQLite shape is a
+  product decision, not an accident.
+
+## License
+
+By contributing, you agree that your contribution is licensed under
+GPL-3.0, matching the rest of the project. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -155,6 +155,24 @@ The MCP server is available at `http://localhost:8080/mcp/` using Server-Sent Ev
 }
 ```
 
+### Claude Code (`.mcp.json` in your project root)
+
+```json
+{
+  "mcpServers": {
+    "documcp": {
+      "type": "sse",
+      "url": "http://localhost:8080/mcp/",
+      "headers": {
+        "Authorization": "Bearer <your-api-key>"
+      }
+    }
+  }
+}
+```
+
+Omit the `headers` block when `DOCUMCP_API_KEY` is unset. Restart Claude Code so it picks up the config change; run `/mcp` to confirm the server is connected.
+
 ### Available MCP Tools
 
 | Tool | Description |
@@ -198,6 +216,31 @@ internal/
 web/static/           # embedded HTML/JS/CSS (Alpine.js, dark theme)
 models/               # ONNX model (downloaded at Docker build time)
 ```
+
+## Troubleshooting
+
+**`/api/*` or `/mcp/*` returns 401 `unauthorized`.**
+`DOCUMCP_API_KEY` is set — every request needs `Authorization: Bearer <key>`. Unset it for local-only use, or pass the header from your MCP client.
+
+**The UI loads but `/api/sources` returns 404 in docker-compose.**
+Check `docker compose logs documcp`. The binary inside the container binds to `0.0.0.0:8080` (the image sets `DOCUMCP_BIND_ADDR`); if you changed the port in `config.yaml`, also update the compose `ports:` mapping and — if running outside compose — set `DOCUMCP_BIND_ADDR=0.0.0.0:<new-port>`.
+
+**Stored GitHub / Azure DevOps tokens fail to decrypt after a restart.**
+`DOCUMCP_SECRET_KEY` either changed or was never set. A missing key means DocuMcp generates an ephemeral key per run. Re-auth the source in the UI and set a persistent key. Generate one with `openssl rand -hex 32`.
+
+**Semantic search returns no results but keyword search works.**
+The ONNX embedding model failed to load. Check startup logs for `embedding model not loaded` — usually `DOCUMCP_MODEL_PATH` points to a missing directory. The container image includes the model at `/app/models/all-MiniLM-L6-v2`; for a bare-binary install, export the model yourself with [optimum-cli](https://huggingface.co/docs/optimum/exporters/onnx/usage_guides/export_a_model).
+
+**A source shows 0 pages after a crawl.**
+Check the server logs. Common causes: GitHub PAT missing **Contents: Read-only** on the target repo (manifests as `unauthorized — token missing or lacks repo scope`); `include_path` with a typo so no file matches; the web source's sitemap is outside the `include_path` prefix. Trigger **Crawl Now** in the UI and watch the progress badge — it shows `N / Total pages` during a run.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the development loop, code style, and what I'm likely to accept or push back on.
+
+## Security
+
+To report a vulnerability, see [SECURITY.md](SECURITY.md).
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,70 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+If you believe you have found a security issue in DocuMcp, please open a
+private report via GitHub Security Advisories:
+
+<https://github.com/mathwro/DocuMcp/security/advisories/new>
+
+Please do **not** file a public issue or pull request for security reports.
+
+When reporting, include:
+
+- A description of the issue and its impact
+- Steps or a minimal reproducer
+- The version or commit SHA you observed it on
+- Any mitigations you are already aware of
+
+I aim to acknowledge reports within seven days and to ship a fix or a
+coordinated-disclosure plan within thirty days of acknowledgement. I am a
+single maintainer — response times are best-effort.
+
+## Supported versions
+
+Security fixes are only backported to the latest tagged release and the
+`main` branch. Older tags are not maintained.
+
+## Threat model and non-goals
+
+DocuMcp is designed as a **single-user, local-network** service. The default
+bind address is `127.0.0.1:<port>` and the admin UI and MCP endpoints are
+intended to be accessed from the same machine.
+
+The following threats are in scope:
+
+- **SSRF** through the web crawler or any source adapter (redirect hops
+  re-validated, private/metadata IPs blocked via DNS resolution)
+- **XSS** in the Web UI from untrusted source URLs (`safeHref` collapses
+  non-http(s) hrefs to `#`, strict CSP)
+- **Source URL smuggling** — non-http(s) schemes rejected at the REST
+  boundary when creating a source
+- **Token exfiltration** via the REST API — `Source.Auth` is marked
+  `json:"-"` so stored secrets do not round-trip through `/api/sources`
+- **Timing side channels** on the API bearer token comparison
+  (`crypto/subtle.ConstantTimeCompare`)
+- **Token storage at rest** — PATs and OAuth tokens are encrypted with
+  AES-256-GCM using `DOCUMCP_SECRET_KEY`
+
+The following are **not** in scope:
+
+- Multi-tenant hosting or running DocuMcp as an internet-exposed service
+  without an authenticating reverse proxy and `DOCUMCP_API_KEY`
+- Attacks from someone who already has write access to `config.yaml`
+  or the SQLite database on disk — those are treated as trusted inputs
+- DoS via crawling very large sources (use `include_path` to scope)
+- Supply chain (upstream Go modules, ONNX model, base container image) —
+  I trust the standard Go module proxy, Hugging Face, and the Debian
+  bookworm-slim base image
+
+## Configuring a hardened deployment
+
+If you do expose DocuMcp beyond a single local user:
+
+1. Set `DOCUMCP_API_KEY` to a strong random value (32+ bytes).
+2. Place it behind a TLS-terminating reverse proxy (nginx, Caddy,
+   Traefik) — DocuMcp does not serve TLS itself.
+3. Keep `DOCUMCP_BIND_ADDR` on a private interface and let the reverse
+   proxy reach it over loopback or a private network.
+4. Set `DOCUMCP_SECRET_KEY` to a persistent 32-byte value so stored
+   tokens survive restarts; back the SQLite data volume up.


### PR DESCRIPTION
## Summary
- **SECURITY.md** — private-advisory reporting channel, documented threat model (single-user local service by default), and a short deployment-hardening guide for cases where DocuMcp is exposed beyond the local machine.
- **CONTRIBUTING.md** — dev loop (`make build` / `make test` with CGo + sqlite_fts5), PR expectations, code style reminders lifted from existing patterns, and an explicit statement on what scope is in/out of bounds.
- **README** gains a Claude Code `.mcp.json` snippet next to the existing Claude Desktop one; a troubleshooting section covering the real-world failure modes (401 without API key, 0 pages after crawl, ephemeral key after restart, missing ONNX model, port mapping mismatch); and contributing/security cross-links.
- **.env.example** expanded to document every tunable env var, not just `DOCUMCP_SECRET_KEY`.
- **.github/copilot-instructions.md** refreshed so assistants get the current reality: `github_repo` adapter listed in the source table, GitHub auth documented as user-supplied PAT (not device code), `internal/httpsafe` noted as the SSRF pinch-point, default bind address documented.

## Test plan
- [x] `gofmt` / `go vet` / `go test` unaffected (docs-only change; Go code untouched)
- [ ] Preview: open README on the branch and verify the new Claude Code JSON renders and the troubleshooting bullets make sense
- [ ] Manual: follow the README's Claude Code `.mcp.json` snippet against a running instance and confirm `/mcp` in Claude Code shows the server connected