### PR TITLE
Cleanup: CSP, 409 duplicate crawl, scheduler ctx, config template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,16 @@
 bin/
 *.db
 .env
+config.yaml
+coverage.out
+coverage.html
+*.prof
+
+# IDE / editor
+.vscode/
+.idea/
+*.swp
+*.swo
+.DS_Store
+
 docs/superpowers/

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,6 @@ init:
 	@if [ -f config.yaml ]; then \
 		echo "config.yaml already exists, skipping"; \
 	else \
-		printf 'server:\n  port: 8080\n  data_dir: /app/data\n\nsources:\n  # - name: Example Docs\n  #   type: web\n  #   url: https://docs.example.com/\n  #   crawl_schedule: "@weekly"\n' > config.yaml; \
-		echo "Created config.yaml with defaults"; \
+		cp config.example.yaml config.yaml; \
+		echo "Created config.yaml from config.example.yaml"; \
 	fi

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,32 @@
+server:
+  port: 8080
+  data_dir: /app/data
+
+sources:
+  # Web crawl, restricted to a path prefix:
+  # - name: ArgoCD Operator Manual
+  #   type: web
+  #   url: https://argo-cd.readthedocs.io/en/stable/
+  #   include_path: https://argo-cd.readthedocs.io/en/stable/operator-manual/
+  #   crawl_schedule: "@weekly"
+
+  # GitHub wiki (public or with a fine-grained PAT for private):
+  # - name: My Project Wiki
+  #   type: github_wiki
+  #   repo: owner/repo
+  #   crawl_schedule: "@daily"
+
+  # GitHub repo tree (Markdown + .txt), optionally scoped to a subfolder:
+  # - name: My Project Docs
+  #   type: github_repo
+  #   repo: owner/repo
+  #   branch: main
+  #   include_path: docs/
+  #   crawl_schedule: "@daily"
+
+  # Azure DevOps wiki (Microsoft device code flow):
+  # - name: Team Wiki
+  #   type: azure_devops
+  #   url: https://dev.azure.com/org/project
+  #   base_url: https://dev.azure.com/org/project/_apis/wiki/wikis/wiki-name
+  #   crawl_schedule: "@weekly"

--- a/config.yaml
+++ b/config.yaml
@@ -1,9 +1,0 @@
-server:
-  port: 8080
-  data_dir: /app/data
-
-sources:
-  - name: Harbor Docs
-    type: web
-    url: https://goharbor.io/docs/2.14.0/
-    crawl_schedule: "@weekly"

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -142,6 +142,11 @@ func (s *Server) triggerCrawl(w http.ResponseWriter, r *http.Request) {
 
 	if s.crawler != nil {
 		s.crawlingMu.Lock()
+		if s.crawlingIDs[id] {
+			s.crawlingMu.Unlock()
+			writeError(w, http.StatusConflict, "crawl already in progress for this source")
+			return
+		}
 		s.crawlingIDs[id] = true
 		s.crawlingMu.Unlock()
 		crawlCtx := s.ctx

--- a/internal/api/handlers_internal_test.go
+++ b/internal/api/handlers_internal_test.go
@@ -1,0 +1,44 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/mathwro/DocuMcp/internal/crawler"
+	"github.com/mathwro/DocuMcp/internal/db"
+)
+
+// TestTriggerCrawl_Returns409WhenAlreadyCrawling verifies that a second crawl
+// request for a source already marked in-flight returns 409 Conflict instead
+// of silently spawning a second goroutine.
+func TestTriggerCrawl_Returns409WhenAlreadyCrawling(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := db.Open(tmpDir + "/test.db")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	id, err := store.InsertSource(db.Source{Name: "CrawlMe", Type: "web", URL: "https://example.com"})
+	if err != nil {
+		t.Fatalf("InsertSource: %v", err)
+	}
+
+	// Real crawler instance so the handler takes the "crawler != nil" branch.
+	// The handler's conflict check fires before any adapter call runs.
+	srv := NewServer(store, crawler.New(store, nil), nil, make([]byte, 32))
+
+	srv.crawlingMu.Lock()
+	srv.crawlingIDs[id] = true
+	srv.crawlingMu.Unlock()
+
+	r := httptest.NewRequest(http.MethodPost, "/api/sources/"+strconv.FormatInt(id, 10)+"/crawl", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409 Conflict, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -118,8 +118,11 @@ func securityMiddleware(next http.Handler) http.Handler {
 		h.Set("X-Content-Type-Options", "nosniff")
 		h.Set("X-Frame-Options", "DENY")
 		h.Set("Referrer-Policy", "no-referrer")
+		// Alpine.js requires 'unsafe-eval' to evaluate directive expressions.
+		// 'unsafe-inline' is kept on style-src for the UI's inline style="..."
+		// attributes; it is NOT on script-src — no inline <script> is emitted.
 		h.Set("Content-Security-Policy",
-			"default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'")
+			"default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'")
 
 		// CORS: only allow cross-origin requests from loopback addresses.
 		// Requests from external sites are denied by omitting the header.

--- a/internal/crawler/scheduler.go
+++ b/internal/crawler/scheduler.go
@@ -16,14 +16,19 @@ type Scheduler struct {
 	cron    *cron.Cron
 	crawler *Crawler
 	store   *db.Store
+	ctx     context.Context    // base context for scheduled crawls
+	cancel  context.CancelFunc // cancels ctx on Stop
 }
 
 // NewScheduler returns a new Scheduler. Call Load to register jobs and start the cron runner.
 func NewScheduler(c *Crawler, store *db.Store) *Scheduler {
+	ctx, cancel := context.WithCancel(context.Background())
 	return &Scheduler{
 		cron:    cron.New(),
 		crawler: c,
 		store:   store,
+		ctx:     ctx,
+		cancel:  cancel,
 	}
 }
 
@@ -52,7 +57,7 @@ func (s *Scheduler) Load(cfg *config.Config) {
 			for _, dbSrc := range sources {
 				if dbSrc.Name == srcCopy.Name {
 					slog.Info("scheduled crawl", "source", dbSrc.Name)
-					if err := s.crawler.Crawl(context.Background(), dbSrc); err != nil {
+					if err := s.crawler.Crawl(s.ctx, dbSrc); err != nil {
 						slog.Error("scheduled crawl failed", "source", dbSrc.Name, "err", err)
 					}
 					return
@@ -69,10 +74,12 @@ func (s *Scheduler) Load(cfg *config.Config) {
 }
 
 // Stop halts all scheduled crawl jobs and returns a context that is cancelled
-// once all in-flight jobs have finished. Callers may block on ctx.Done() to
-// wait for a clean shutdown.
+// once all in-flight jobs have finished. The base scheduler context is also
+// cancelled so any long-running crawl observes ctx.Done() and unwinds promptly
+// rather than stalling shutdown.
 func (s *Scheduler) Stop() context.Context {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.cancel()
 	return s.cron.Stop()
 }


### PR DESCRIPTION
## Summary
- **Stop tracking `config.yaml`.** Ship `config.example.yaml` with commented examples for every source type; `make init` now copies that template. Fresh clones no longer start with someone else's Harbor feed.
- **`.gitignore`**: add `.vscode/`, `.idea/`, `*.swp`, `coverage.out`, `*.prof`, `.DS_Store`, and `config.yaml` itself.
- **Tighter CSP**: drop `'unsafe-inline'` from `script-src` (no inline `<script>` is emitted). `'unsafe-eval'` stays (Alpine), `style-src 'unsafe-inline'` stays (inline `style=""` attributes).
- **`POST /api/sources/{id}/crawl` now returns 409 Conflict** when a crawl is already in flight for the same source. Previously a second request silently spawned a second crawler goroutine for the same source.
- **Scheduler ctx plumbing**: `NewScheduler` now owns a `context.WithCancel`. `Stop()` cancels it before waiting for in-flight jobs, so a long-running scheduled crawl observes `ctx.Done()` and unwinds promptly rather than stalling process shutdown.

## Also done (not in commit)
- Rotated my local `.env` secret key. The file is gitignored so this is local-only, but documenting it here for completeness — the prior key was present in earlier session transcripts.

## Test plan
- [x] `CGO_ENABLED=1 go test -tags sqlite_fts5 -race ./...` passes, including a new internal-package test for the 409 path
- [x] `gofmt` / `go vet` clean
- [ ] Manual: `make init` from a clean checkout creates `config.yaml` as a copy of the example
- [ ] Manual: visit the UI, confirm nothing breaks with the tightened CSP (no console errors, Alpine bindings still fire, inline styles still apply)
- [ ] Manual: click **Crawl Now** twice quickly on the same source, confirm the second click returns 409 in devtools network