### PR TITLE
fix(config): debounce watcher events to avoid reading mid-write

### DIFF
--- a/internal/config/watcher.go
+++ b/internal/config/watcher.go
@@ -3,9 +3,15 @@ package config
 import (
 	"log/slog"
 	"sync"
+	"time"
 
 	"github.com/fsnotify/fsnotify"
 )
+
+// debounceWindow collapses the burst of events that editors and os.WriteFile
+// emit for a single logical save (e.g. TRUNCATE + WRITE) so we only Load once
+// the file has settled — otherwise we can read it mid-write and see empty YAML.
+const debounceWindow = 150 * time.Millisecond
 
 // Watcher watches a config file for changes and calls onChange with the new config.
 type Watcher struct {
@@ -28,22 +34,46 @@ func Watch(path string, onChange func(*Config)) (*Watcher, error) {
 	w.wg.Add(1)
 	go func() {
 		defer w.wg.Done()
+
+		var timer *time.Timer
+		var timerC <-chan time.Time
 		for {
 			select {
 			case event, ok := <-fsw.Events:
 				if !ok {
+					if timer != nil {
+						timer.Stop()
+					}
 					return
 				}
 				if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) {
-					cfg, err := Load(path)
-					if err != nil {
-						slog.Error("reload config", "path", path, "err", err)
-						continue
+					if timer == nil {
+						timer = time.NewTimer(debounceWindow)
+						timerC = timer.C
+					} else {
+						if !timer.Stop() {
+							select {
+							case <-timer.C:
+							default:
+							}
+						}
+						timer.Reset(debounceWindow)
 					}
-					onChange(cfg)
 				}
+			case <-timerC:
+				timer = nil
+				timerC = nil
+				cfg, err := Load(path)
+				if err != nil {
+					slog.Error("reload config", "path", path, "err", err)
+					continue
+				}
+				onChange(cfg)
 			case err, ok := <-fsw.Errors:
 				if !ok {
+					if timer != nil {
+						timer.Stop()
+					}
 					return
 				}
 				slog.Error("watcher error", "err", err)


### PR DESCRIPTION
## Summary
- `os.WriteFile` truncates before writing, emitting two WRITE events for a single save
- Watcher was firing `Load` on the truncate event, reading an empty file, and applying default port 8080
- Real user editing config.yaml could briefly see the server flap to defaults
- Fix: 150ms debounce window around inbound events so Load runs once the file has settled

## Test plan
- [x] \`go test -race -count=20 ./internal/config/\` — 20 iterations green
- [x] Full suite passes

## Context
Found while investigating flaky \`TestWatcher_CallsCallbackOnChange\` in CI on PRs #10 and #12 — this is the underlying cause, not test flakiness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)