### PR TITLE
test: skip FTS5-dependent tests cleanly when sqlite_fts5 tag missing

### DIFF
--- a/internal/api/handlers_internal_test.go
+++ b/internal/api/handlers_internal_test.go
@@ -8,18 +8,14 @@ import (
 
 	"github.com/mathwro/DocuMcp/internal/crawler"
 	"github.com/mathwro/DocuMcp/internal/db"
+	"github.com/mathwro/DocuMcp/internal/testutil"
 )
 
 // TestTriggerCrawl_Returns409WhenAlreadyCrawling verifies that a second crawl
 // request for a source already marked in-flight returns 409 Conflict instead
 // of silently spawning a second goroutine.
 func TestTriggerCrawl_Returns409WhenAlreadyCrawling(t *testing.T) {
-	tmpDir := t.TempDir()
-	store, err := db.Open(tmpDir + "/test.db")
-	if err != nil {
-		t.Fatalf("open db: %v", err)
-	}
-	t.Cleanup(func() { _ = store.Close() })
+	store := testutil.OpenStoreFile(t)
 
 	id, err := store.InsertSource(db.Source{Name: "CrawlMe", Type: "web", URL: "https://example.com"})
 	if err != nil {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -11,16 +11,12 @@ import (
 	"github.com/mathwro/DocuMcp/internal/api"
 	"github.com/mathwro/DocuMcp/internal/auth"
 	"github.com/mathwro/DocuMcp/internal/db"
+	"github.com/mathwro/DocuMcp/internal/testutil"
 )
 
 func openTestStore(t *testing.T) *db.Store {
 	t.Helper()
-	store, err := db.Open(":memory:")
-	if err != nil {
-		t.Fatalf("db.Open: %v", err)
-	}
-	t.Cleanup(func() { store.Close() })
-	return store
+	return testutil.OpenStore(t)
 }
 
 func TestListSources_Empty(t *testing.T) {

--- a/internal/auth/store_test.go
+++ b/internal/auth/store_test.go
@@ -6,14 +6,11 @@ import (
 
 	"github.com/mathwro/DocuMcp/internal/auth"
 	"github.com/mathwro/DocuMcp/internal/db"
+	"github.com/mathwro/DocuMcp/internal/testutil"
 )
 
 func TestTokenStore_SaveAndLoad(t *testing.T) {
-	dbStore, err := db.Open(":memory:")
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
-	defer dbStore.Close()
+	dbStore := testutil.OpenStore(t)
 
 	// Insert a source row so the foreign key constraint on tokens is satisfied.
 	srcID, err := dbStore.InsertSource(db.Source{
@@ -50,16 +47,12 @@ func TestTokenStore_SaveAndLoad(t *testing.T) {
 }
 
 func TestTokenStore_LoadNotFound(t *testing.T) {
-	dbStore, err := db.Open(":memory:")
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
-	defer dbStore.Close()
+	dbStore := testutil.OpenStore(t)
 
 	key := []byte("test-encryption-key-32-bytes!!!!")
 	ts := auth.NewTokenStore(dbStore, key)
 
-	_, err = ts.Load(99, "microsoft")
+	_, err := ts.Load(99, "microsoft")
 	if err == nil {
 		t.Fatal("expected error for missing token, got nil")
 	}

--- a/internal/crawler/crawler_test.go
+++ b/internal/crawler/crawler_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mathwro/DocuMcp/internal/config"
 	"github.com/mathwro/DocuMcp/internal/crawler"
 	"github.com/mathwro/DocuMcp/internal/db"
+	"github.com/mathwro/DocuMcp/internal/testutil"
 )
 
 // stubAdapter is a test-only adapter that returns a fixed set of pages without
@@ -27,11 +28,7 @@ func init() {
 }
 
 func TestCrawler_IndexesPages(t *testing.T) {
-	store, err := db.Open(":memory:")
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
-	defer store.Close()
+	store := testutil.OpenStore(t)
 
 	srcID, err := store.InsertSource(db.Source{Name: "Test", Type: "stub", URL: "http://example.test"})
 	if err != nil {
@@ -57,14 +54,10 @@ func TestCrawler_IndexesPages(t *testing.T) {
 }
 
 func TestCrawler_UnknownType(t *testing.T) {
-	store, err := db.Open(":memory:")
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
-	defer store.Close()
+	store := testutil.OpenStore(t)
 
 	c := crawler.New(store, nil)
-	err = c.Crawl(context.Background(), db.Source{ID: 1, Type: "unknown_source_type"})
+	err := c.Crawl(context.Background(), db.Source{ID: 1, Type: "unknown_source_type"})
 	if err == nil {
 		t.Fatal("expected error for unknown source type, got nil")
 	}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/mathwro/DocuMcp/internal/db"
+	"github.com/mathwro/DocuMcp/internal/testutil"
 )
 
 func TestSource_MarshalJSON_OmitsAuthToken(t *testing.T) {
@@ -25,19 +26,11 @@ func TestSource_MarshalJSON_OmitsAuthToken(t *testing.T) {
 }
 
 func TestOpen_CreatesSchema(t *testing.T) {
-	store, err := db.Open(":memory:")
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
-	defer store.Close()
+	_ = testutil.OpenStore(t)
 }
 
 func TestInsertAndListSources(t *testing.T) {
-	store, err := db.Open(":memory:")
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
-	defer store.Close()
+	store := testutil.OpenStore(t)
 
 	id, err := store.InsertSource(db.Source{
 		Name: "Test Source",
@@ -67,11 +60,7 @@ func TestInsertAndListSources(t *testing.T) {
 }
 
 func TestUpsertAndGetPage(t *testing.T) {
-	store, err := db.Open(":memory:")
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
-	defer store.Close()
+	store := testutil.OpenStore(t)
 
 	sourceID, err := store.InsertSource(db.Source{Name: "S", Type: "web"})
 	if err != nil {
@@ -102,11 +91,7 @@ func TestUpsertAndGetPage(t *testing.T) {
 }
 
 func TestUpsertPage_UpdatesOnConflict(t *testing.T) {
-	store, err := db.Open(":memory:")
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
-	defer store.Close()
+	store := testutil.OpenStore(t)
 
 	srcID, err := store.InsertSource(db.Source{Name: "S", Type: "web"})
 	if err != nil {
@@ -129,11 +114,7 @@ func TestUpsertPage_UpdatesOnConflict(t *testing.T) {
 }
 
 func TestDeleteSource(t *testing.T) {
-	store, err := db.Open(":memory:")
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
-	defer store.Close()
+	store := testutil.OpenStore(t)
 
 	id, err := store.InsertSource(db.Source{Name: "S", Type: "web"})
 	if err != nil {
@@ -152,11 +133,7 @@ func TestDeleteSource(t *testing.T) {
 }
 
 func TestUpdateSourcePageCount(t *testing.T) {
-	store, err := db.Open(":memory:")
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
-	defer store.Close()
+	store := testutil.OpenStore(t)
 
 	id, err := store.InsertSource(db.Source{Name: "S", Type: "web"})
 	if err != nil {
@@ -175,11 +152,7 @@ func TestUpdateSourcePageCount(t *testing.T) {
 }
 
 func TestGetSource(t *testing.T) {
-	store, err := db.Open(":memory:")
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
-	defer store.Close()
+	store := testutil.OpenStore(t)
 
 	id, err := store.InsertSource(db.Source{Name: "Test", Type: "web", URL: "https://example.com"})
 	if err != nil {
@@ -196,11 +169,7 @@ func TestGetSource(t *testing.T) {
 }
 
 func TestGetSourceIDByName(t *testing.T) {
-	store, err := db.Open(":memory:")
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
-	defer store.Close()
+	store := testutil.OpenStore(t)
 
 	id, err := store.InsertSource(db.Source{Name: "Named Source", Type: "web"})
 	if err != nil {
@@ -217,11 +186,7 @@ func TestGetSourceIDByName(t *testing.T) {
 }
 
 func TestUpsertAndGetToken(t *testing.T) {
-	store, err := db.Open(":memory:")
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
-	defer store.Close()
+	store := testutil.OpenStore(t)
 
 	srcID, err := store.InsertSource(db.Source{Name: "S", Type: "web"})
 	if err != nil {
@@ -244,11 +209,7 @@ func TestUpsertAndGetToken(t *testing.T) {
 }
 
 func TestUpsertEmbedding(t *testing.T) {
-	store, err := db.Open(":memory:")
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
-	defer store.Close()
+	store := testutil.OpenStore(t)
 
 	srcID, err := store.InsertSource(db.Source{Name: "S", Type: "web"})
 	if err != nil {
@@ -285,13 +246,9 @@ func TestUpsertEmbedding(t *testing.T) {
 }
 
 func TestGetPageByURL_NotFound(t *testing.T) {
-	store, err := db.Open(":memory:")
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
-	defer store.Close()
+	store := testutil.OpenStore(t)
 
-	_, err = store.GetPageByURL("https://nonexistent.example.com")
+	_, err := store.GetPageByURL("https://nonexistent.example.com")
 	if err == nil {
 		t.Fatal("expected error for nonexistent URL, got nil")
 	}
@@ -301,11 +258,7 @@ func TestGetPageByURL_NotFound(t *testing.T) {
 }
 
 func TestInsertSource_github_repo_persists_branch(t *testing.T) {
-	store, err := db.Open(":memory:")
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
-	defer store.Close()
+	store := testutil.OpenStore(t)
 
 	id, err := store.InsertSource(db.Source{
 		Name:        "example",

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -3,7 +3,6 @@ package mcp_test
 import (
 	"context"
 	"encoding/json"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -11,18 +10,13 @@ import (
 
 	"github.com/mathwro/DocuMcp/internal/db"
 	mcpserver "github.com/mathwro/DocuMcp/internal/mcp"
+	"github.com/mathwro/DocuMcp/internal/testutil"
 )
 
 // openTestDB creates a temporary SQLite database for testing.
 func openTestDB(t *testing.T) *db.Store {
 	t.Helper()
-	dir := t.TempDir()
-	store, err := db.Open(filepath.Join(dir, "test.db"))
-	if err != nil {
-		t.Fatalf("open test db: %v", err)
-	}
-	t.Cleanup(func() { store.Close() })
-	return store
+	return testutil.OpenStoreFile(t)
 }
 
 // connectTestClient connects an in-memory MCP client to the given server and

--- a/internal/search/browse_test.go
+++ b/internal/search/browse_test.go
@@ -6,15 +6,12 @@ import (
 
 	"github.com/mathwro/DocuMcp/internal/db"
 	"github.com/mathwro/DocuMcp/internal/search"
+	"github.com/mathwro/DocuMcp/internal/testutil"
 )
 
 func setupBrowseDB(t *testing.T) (*db.Store, int64) {
 	t.Helper()
-	store, err := db.Open(":memory:")
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
-	t.Cleanup(func() { store.Close() })
+	store := testutil.OpenStore(t)
 
 	srcID, err := store.InsertSource(db.Source{Name: "S", Type: "web"})
 	if err != nil {

--- a/internal/search/fts_test.go
+++ b/internal/search/fts_test.go
@@ -7,16 +7,12 @@ import (
 
 	"github.com/mathwro/DocuMcp/internal/db"
 	"github.com/mathwro/DocuMcp/internal/search"
+	"github.com/mathwro/DocuMcp/internal/testutil"
 )
 
 func setupTestDB(t *testing.T) *db.Store {
 	t.Helper()
-	store, err := db.Open(":memory:")
-	if err != nil {
-		t.Fatalf("db.Open: %v", err)
-	}
-	t.Cleanup(func() { store.Close() })
-	return store
+	return testutil.OpenStore(t)
 }
 
 func TestFTS_ReturnsRelevantResults(t *testing.T) {

--- a/internal/testutil/sqlite.go
+++ b/internal/testutil/sqlite.go
@@ -1,0 +1,39 @@
+// Package testutil provides shared helpers for tests across packages.
+package testutil
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mathwro/DocuMcp/internal/db"
+)
+
+// OpenStore opens an in-memory store for tests. If the test binary was
+// built without the sqlite_fts5 tag the schema exec fails with
+// "no such module: fts5"; in that case the test is skipped with a
+// message pointing at the correct invocation instead of erroring out.
+func OpenStore(t *testing.T) *db.Store {
+	t.Helper()
+	return openAt(t, ":memory:")
+}
+
+// OpenStoreFile opens a file-backed store inside t.TempDir() for tests
+// that need an on-disk database. Same FTS5 skip semantics as OpenStore.
+func OpenStoreFile(t *testing.T) *db.Store {
+	t.Helper()
+	return openAt(t, filepath.Join(t.TempDir(), "test.db"))
+}
+
+func openAt(t *testing.T, path string) *db.Store {
+	t.Helper()
+	store, err := db.Open(path)
+	if err != nil {
+		if strings.Contains(err.Error(), "no such module: fts5") {
+			t.Skip("SQLite FTS5 required; run `make test` or `go test -tags sqlite_fts5 ./...`")
+		}
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}


### PR DESCRIPTION
## Summary
- Default `go test ./...` previously failed with `no such module: fts5`. Now FTS5-dependent tests skip cleanly with a message pointing at `make test` or the correct flag set.
- Introduced `internal/testutil` with `OpenStore(t)` / `OpenStoreFile(t)` helpers that detect the missing module at `db.Open` time and call `t.Skip`.
- Routed all test files that open the DB (`db`, `api`, `mcp`, `search`, `auth`, `crawler`) through the shared helper.

## CI impact
None — `.github/workflows/ci.yml` runs `go test -tags sqlite_fts5 -race ./...`, which takes the full-coverage path. Verified locally:

```
$ CGO_ENABLED=1 go test -tags sqlite_fts5 -count=1 -run TestOpen_CreatesSchema -v ./internal/db/
--- PASS: TestOpen_CreatesSchema (0.00s)

$ go test -count=1 -run TestOpen_CreatesSchema -v ./internal/db/
    db_test.go:29: SQLite FTS5 required; run `make test` or `go test -tags sqlite_fts5 ./...`
--- SKIP: TestOpen_CreatesSchema (0.00s)
```

## Test plan
- [x] CI tagged invocation: all packages pass
- [x] Default invocation: FTS5-dependent tests skip with friendly message, other tests still run
- [x] `gofmt -l .` clean
- [x] `go vet -tags sqlite_fts5 ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)