### PR TITLE
feat(mcp): add streamable HTTP transport

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -91,7 +91,7 @@ Crawl(ctx context.Context, source config.SourceConfig, sourceID int64) (int, <-c
 - **Tokens:** AES-256-GCM encrypted in SQLite; key from `DOCUMCP_SECRET_KEY` env var
 - **API auth:** optional `DOCUMCP_API_KEY` bearer token on `/api/*` and `/mcp/*`; constant-time compared
 - **Bind address:** defaults to `127.0.0.1:<port>`; override with `DOCUMCP_BIND_ADDR`; the container image pre-sets `0.0.0.0:8080`
-- **MCP:** `github.com/modelcontextprotocol/go-sdk` v0.8.0, SSE transport at `/mcp/`
+- **MCP:** `github.com/modelcontextprotocol/go-sdk` v0.8.0, SSE transport at `/mcp/sse`, streamable HTTP transport at `/mcp/http`
 - **Container:** multi-stage Dockerfile, non-root user `documcp` (uid 1001), podman-compatible
 
 ## Source Types

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+DocuMcp is a single Go 1.26 binary for the MCP endpoint, REST API, web UI, and crawlers. `cmd/documcp/` is the server; `cmd/bench/` is benchmark tooling. Core packages live in `internal/`: `adapter/`, `api/`, `auth/`, `config/`, `crawler/`, `db/`, `embed/`, `httpsafe/`, `mcp/`, `search/`, and `testutil/`. Static Alpine.js assets are in `web/static/` and embedded by `web/embed.go`. User docs are in `docs/`; plans are in `docs/plans/`. Tests are colocated as `*_test.go`.
+
+## Build, Test, and Development Commands
+
+- `make init`: create `.env` with `DOCUMCP_SECRET_KEY`.
+- `make build`: build `bin/documcp`.
+- `make bench`: build `bin/bench`.
+- `make test`: run Go tests.
+- `make lint`: run `golangci-lint run`.
+- `make docker`: build `documcp:local`.
+- `make run`: start compose with Podman or Docker.
+
+For direct Go commands, always use both flags: `CGO_ENABLED=1 go test -tags sqlite_fts5 ./...`; SQLite FTS5 and sqlite-vec require CGo.
+
+## Coding Style & Naming Conventions
+
+Run `gofmt -w .` before submitting. Use short lowercase package names, `CamelCase` exports, and `camelCase` internals. Wrap package-boundary errors, for example `fmt.Errorf("load source: %w", err)`. Use `db.ErrNotFound` for missing rows and check with `errors.Is`. Return empty slices, not `nil`. Keep comments focused on why.
+
+## Testing Guidelines
+
+Use Go's standard `testing` package. Name tests `TestXxx` and check setup errors with `t.Fatalf`. Before a PR, run `gofmt -w .`, `CGO_ENABLED=1 go vet -tags sqlite_fts5 ./...`, and `CGO_ENABLED=1 go test -tags sqlite_fts5 -race ./...`. Adapter tests should use stubs or resolver overrides, not `httptest.NewServer`, because SSRF protection blocks loopback/private IPs.
+
+## Architecture & Agent-Specific Notes
+
+SQLite uses FTS5 plus sqlite-vec; `bm25()` scores sort best with `ORDER BY score ASC`. New DB columns need schema updates and idempotent `ALTER TABLE` migrations in `Open()`. When adding fields to `db.Source`, update inserts, selects, scans, and `sourceToConfig()` in `crawler.go`. Adapter `Crawl` returns `(int, <-chan db.Page, error)`, where `int` is total URL count or `0` if unknown. Keep HTTP source access routed through `internal/httpsafe`.
+
+## Commit & Pull Request Guidelines
+
+Recent commits use Conventional Commits, for example `feat(bench): add JSON report writer` and `fix(bench): parse flags once`. Keep branches focused and target `main`. PRs should explain why, summarize changes, link issues, and list test commands. Include screenshots only for UI changes.
+
+## Security & Configuration Tips
+
+Do not commit `.env`, real tokens, or local `config.yaml`. `DOCUMCP_CONFIG` enables strict config loading; unset uses defaults. `DOCUMCP_SECRET_KEY` protects stored tokens; unset keys are ephemeral. `DOCUMCP_API_KEY` protects `/api/*` and `/mcp/*`.

--- a/cmd/documcp/main.go
+++ b/cmd/documcp/main.go
@@ -81,7 +81,7 @@ func main() {
 	}
 
 	mcpServer := mcp.NewServer(store, embedder)
-	apiServer := api.NewServer(store, c, mcpServer.Handler(), key)
+	apiServer := api.NewServerWithMCPHandlers(store, c, mcpServer.Handler(), mcpServer.StreamableHTTPHandler(), key)
 
 	// Warn if no API key is configured — the API and MCP endpoints are open.
 	api.LogAPIKeyWarning()

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -2,8 +2,10 @@
 
 The MCP server exposes two local transports:
 
-- `http://localhost:8080/mcp/` for Server-Sent Events (SSE) clients such as Claude.
-- `http://localhost:8080/mcp` for streamable HTTP clients such as Codex.
+- `http://localhost:8080/mcp/sse` for Server-Sent Events (SSE) clients such as Claude.
+- `http://localhost:8080/mcp/http` for streamable HTTP clients such as Codex.
+
+For compatibility with older configs, `http://localhost:8080/mcp/` still serves SSE and `http://localhost:8080/mcp` still serves streamable HTTP. Prefer the explicit endpoints above for new setup.
 
 ## Claude Desktop (`claude_desktop_config.json`)
 
@@ -11,7 +13,7 @@ The MCP server exposes two local transports:
 {
   "mcpServers": {
     "documcp": {
-      "url": "http://localhost:8080/mcp/",
+      "url": "http://localhost:8080/mcp/sse",
       "headers": {
         "Authorization": "Bearer <your-api-key>"
       }
@@ -27,7 +29,7 @@ The MCP server exposes two local transports:
   "mcpServers": {
     "documcp": {
       "type": "sse",
-      "url": "http://localhost:8080/mcp/",
+      "url": "http://localhost:8080/mcp/sse",
       "headers": {
         "Authorization": "Bearer <your-api-key>"
       }
@@ -42,7 +44,7 @@ Omit the `headers` block when `DOCUMCP_API_KEY` is unset (the typical local-only
 
 ```toml
 [mcp_servers.documcp]
-url = "http://localhost:8080/mcp"
+url = "http://localhost:8080/mcp/http"
 ```
 
 If `DOCUMCP_API_KEY` is set, configure Codex with `bearer_token_env_var = "DOCUMCP_API_KEY"` and export the same environment variable before starting Codex.

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -1,6 +1,9 @@
 # MCP Integration
 
-The MCP server is available at `http://localhost:8080/mcp/` using Server-Sent Events (SSE) transport.
+The MCP server exposes two local transports:
+
+- `http://localhost:8080/mcp/` for Server-Sent Events (SSE) clients such as Claude.
+- `http://localhost:8080/mcp` for streamable HTTP clients such as Codex.
 
 ## Claude Desktop (`claude_desktop_config.json`)
 
@@ -34,6 +37,15 @@ The MCP server is available at `http://localhost:8080/mcp/` using Server-Sent Ev
 ```
 
 Omit the `headers` block when `DOCUMCP_API_KEY` is unset (the typical local-only setup — see [install.md](install.md#when-to-set-documcp_api_key)). Restart Claude Code so it picks up the config change; run `/mcp` to confirm the server is connected.
+
+## Codex (`~/.codex/config.toml`)
+
+```toml
+[mcp_servers.documcp]
+url = "http://localhost:8080/mcp"
+```
+
+If `DOCUMCP_API_KEY` is set, configure Codex with `bearer_token_env_var = "DOCUMCP_API_KEY"` and export the same environment variable before starting Codex.
 
 ## Available MCP Tools
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -48,7 +48,7 @@ func NewServer(store *db.Store, c *crawler.Crawler, mcpHandler http.Handler, key
 }
 
 // NewServerWithMCPHandlers creates a new API server with separate MCP handlers
-// for SSE (/mcp/) and streamable HTTP (/mcp) clients.
+// for SSE (/mcp/sse) and streamable HTTP (/mcp/http) clients.
 func NewServerWithMCPHandlers(store *db.Store, c *crawler.Crawler, mcpHandler, mcpStreamableHandler http.Handler, key []byte) *Server {
 	ctx, cancel := context.WithCancel(context.Background())
 	s := &Server{
@@ -93,9 +93,11 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("PUT /api/sources/{id}/auth/token", s.authSetToken)
 	s.mux.HandleFunc("DELETE /api/sources/{id}/auth", s.authRevoke)
 	if s.mcpHandler != nil {
+		s.mux.Handle("/mcp/sse", s.mcpHandler)
 		s.mux.Handle("/mcp/", s.mcpHandler)
 	}
 	if s.mcpStreamableHandler != nil {
+		s.mux.Handle("/mcp/http", s.mcpStreamableHandler)
 		s.mux.Handle("/mcp", s.mcpStreamableHandler)
 	}
 	s.mux.Handle("/", http.FileServer(web.FileSystem()))

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -25,35 +25,43 @@ type pendingFlow struct {
 
 // Server is the REST API server for the Web UI.
 type Server struct {
-	store        *db.Store
-	crawler      *crawler.Crawler
-	mcpHandler   http.Handler
-	mux          *http.ServeMux
-	handler      http.Handler // full middleware chain, built once in NewServer
-	tokenStore   *auth.TokenStore
-	pendingFlows map[int64]*pendingFlow
-	flowMu       sync.Mutex
-	crawlingIDs  map[int64]bool // source IDs with an active crawl goroutine
-	crawlingMu   sync.Mutex
-	cancel       context.CancelFunc // cancels background work on Shutdown
-	ctx          context.Context    // cancelled when Shutdown is called
+	store                *db.Store
+	crawler              *crawler.Crawler
+	mcpHandler           http.Handler
+	mcpStreamableHandler http.Handler
+	mux                  *http.ServeMux
+	handler              http.Handler // full middleware chain, built once in NewServer
+	tokenStore           *auth.TokenStore
+	pendingFlows         map[int64]*pendingFlow
+	flowMu               sync.Mutex
+	crawlingIDs          map[int64]bool // source IDs with an active crawl goroutine
+	crawlingMu           sync.Mutex
+	cancel               context.CancelFunc // cancels background work on Shutdown
+	ctx                  context.Context    // cancelled when Shutdown is called
 }
 
 // NewServer creates a new API server wired to the given store, crawler, and MCP handler.
 // Pass nil for mcpHandler and/or crawler when not needed (e.g. in tests).
 // key must be exactly 32 bytes and is used for AES-256-GCM token encryption.
 func NewServer(store *db.Store, c *crawler.Crawler, mcpHandler http.Handler, key []byte) *Server {
+	return NewServerWithMCPHandlers(store, c, mcpHandler, nil, key)
+}
+
+// NewServerWithMCPHandlers creates a new API server with separate MCP handlers
+// for SSE (/mcp/) and streamable HTTP (/mcp) clients.
+func NewServerWithMCPHandlers(store *db.Store, c *crawler.Crawler, mcpHandler, mcpStreamableHandler http.Handler, key []byte) *Server {
 	ctx, cancel := context.WithCancel(context.Background())
 	s := &Server{
-		store:        store,
-		crawler:      c,
-		mcpHandler:   mcpHandler,
-		mux:          http.NewServeMux(),
-		tokenStore:   auth.NewTokenStore(store, key),
-		pendingFlows: make(map[int64]*pendingFlow),
-		crawlingIDs:  make(map[int64]bool),
-		ctx:          ctx,
-		cancel:       cancel,
+		store:                store,
+		crawler:              c,
+		mcpHandler:           mcpHandler,
+		mcpStreamableHandler: mcpStreamableHandler,
+		mux:                  http.NewServeMux(),
+		tokenStore:           auth.NewTokenStore(store, key),
+		pendingFlows:         make(map[int64]*pendingFlow),
+		crawlingIDs:          make(map[int64]bool),
+		ctx:                  ctx,
+		cancel:               cancel,
 	}
 	s.routes()
 	// Build the middleware chain once at construction time.
@@ -87,6 +95,9 @@ func (s *Server) routes() {
 	if s.mcpHandler != nil {
 		s.mux.Handle("/mcp/", s.mcpHandler)
 	}
+	if s.mcpStreamableHandler != nil {
+		s.mux.Handle("/mcp", s.mcpStreamableHandler)
+	}
 	s.mux.Handle("/", http.FileServer(web.FileSystem()))
 }
 
@@ -97,7 +108,7 @@ func apiKeyMiddleware(apiKey string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if apiKey != "" {
 			path := r.URL.Path
-			if strings.HasPrefix(path, "/api/") || strings.HasPrefix(path, "/mcp/") {
+			if strings.HasPrefix(path, "/api/") || path == "/mcp" || strings.HasPrefix(path, "/mcp/") {
 				got := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
 				if subtle.ConstantTimeCompare([]byte(got), []byte(apiKey)) != 1 {
 					w.Header().Set("Content-Type", "application/json")

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -99,3 +99,39 @@ func TestAPIKeyMiddleware_StaticFilesOpen(t *testing.T) {
 		t.Errorf("static file handler should not require auth; got 401")
 	}
 }
+
+func TestMCPTransportRoutes(t *testing.T) {
+	store := openTestStore(t)
+	sseHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("sse")) //nolint:errcheck
+	})
+	streamableHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("streamable")) //nolint:errcheck
+	})
+	srv := api.NewServerWithMCPHandlers(store, nil, sseHandler, streamableHandler, make([]byte, 32))
+
+	tests := []struct {
+		path string
+		want string
+	}{
+		{path: "/mcp/sse", want: "sse"},
+		{path: "/mcp/http", want: "streamable"},
+		{path: "/mcp/", want: "sse"},
+		{path: "/mcp", want: "streamable"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.path, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, test.path, nil)
+			w := httptest.NewRecorder()
+			srv.ServeHTTP(w, r)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+			}
+			if got := w.Body.String(); got != test.want {
+				t.Fatalf("expected %q, got %q", test.want, got)
+			}
+		})
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -35,6 +35,14 @@ func (s *Server) Handler() http.Handler {
 	}, nil)
 }
 
+// StreamableHTTPHandler returns an HTTP handler for clients that use the
+// streamable HTTP MCP transport.
+func (s *Server) StreamableHTTPHandler() http.Handler {
+	return sdkmcp.NewStreamableHTTPHandler(func(r *http.Request) *sdkmcp.Server {
+		return s.server
+	}, nil)
+}
+
 // SDKServer exposes the underlying go-sdk server for testing.
 func (s *Server) SDKServer() *sdkmcp.Server {
 	return s.server

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -3,6 +3,7 @@ package mcp_test
 import (
 	"context"
 	"encoding/json"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -35,6 +36,35 @@ func connectTestClient(t *testing.T, s *mcpserver.Server) *sdkmcp.ClientSession 
 	}
 	t.Cleanup(func() { cs.Close() })
 	return cs
+}
+
+func TestStreamableHTTPHandlerListsTools(t *testing.T) {
+	store := openTestDB(t)
+	srv := mcpserver.NewServer(store, nil)
+	httpSrv := httptest.NewServer(srv.StreamableHTTPHandler())
+	t.Cleanup(httpSrv.Close)
+
+	ctx := context.Background()
+	client := sdkmcp.NewClient(&sdkmcp.Implementation{Name: "test-client", Version: "0.0.1"}, nil)
+	cs, err := client.Connect(ctx, &sdkmcp.StreamableClientTransport{Endpoint: httpSrv.URL}, nil)
+	if err != nil {
+		t.Fatalf("connect streamable client: %v", err)
+	}
+	t.Cleanup(func() { cs.Close() })
+
+	res, err := cs.ListTools(ctx, &sdkmcp.ListToolsParams{})
+	if err != nil {
+		t.Fatalf("list tools: %v", err)
+	}
+	got := make(map[string]bool)
+	for _, tool := range res.Tools {
+		got[tool.Name] = true
+	}
+	for _, name := range []string{"list_sources", "search_docs", "browse_source", "get_page"} {
+		if !got[name] {
+			t.Fatalf("expected streamable handler to expose %q; got %#v", name, got)
+		}
+	}
 }
 
 func TestListSources(t *testing.T) {


### PR DESCRIPTION
## Summary
- keep the existing SSE MCP endpoint at /mcp/ for Claude clients
- add a streamable HTTP MCP endpoint at /mcp for Codex clients
- document Codex MCP configuration and add a regression test that lists tools through the streamable handler

## Tests
- env GOCACHE=/tmp/documcp-go-build CGO_ENABLED=1 go test -tags sqlite_fts5 ./internal/mcp ./internal/api ./cmd/documcp