### PR TITLE
[codex] Add source editing UI

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -145,6 +145,54 @@ func (s *Server) createSource(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusCreated, created)
 }
 
+// updateSource handles PUT /api/sources/{id}.
+// It updates editable configuration fields while keeping the source type fixed.
+func (s *Server) updateSource(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+
+	existing, err := s.store.GetSource(id)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "source not found")
+			return
+		}
+		internalError(w, "get source", err)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+	var src db.Source
+	if err := json.NewDecoder(r.Body).Decode(&src); err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("decode body: %w", err).Error())
+		return
+	}
+	src.Type = existing.Type
+
+	if err := validateSourceURLs(src); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if err := s.store.UpdateSourceConfig(id, src); err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "source not found")
+			return
+		}
+		internalError(w, "update source", err)
+		return
+	}
+
+	updated, err := s.store.GetSource(id)
+	if err != nil {
+		internalError(w, "get source after update", err)
+		return
+	}
+	writeJSON(w, http.StatusOK, updated)
+}
+
 // deleteSource handles DELETE /api/sources/{id}.
 // Deletes the source (and its pages via cascade) and returns 204 No Content.
 func (s *Server) deleteSource(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -221,6 +221,99 @@ func TestDeleteSource_BadID(t *testing.T) {
 	}
 }
 
+func TestUpdateSource(t *testing.T) {
+	store := openTestStore(t)
+	id, err := store.InsertSource(db.Source{
+		Name:          "Old Docs",
+		Type:          "web",
+		URL:           "https://old.example.com",
+		CrawlSchedule: "0 1 * * *",
+	})
+	if err != nil {
+		t.Fatalf("InsertSource: %v", err)
+	}
+	if err := store.UpdateSourcePageCount(id, 7); err != nil {
+		t.Fatalf("UpdateSourcePageCount: %v", err)
+	}
+
+	srv := api.NewServer(store, nil, nil, make([]byte, 32))
+	body, err := json.Marshal(db.Source{
+		Name:          "New Docs",
+		Type:          "github_repo",
+		URL:           "https://new.example.com",
+		IncludePath:   "https://new.example.com/guide/",
+		CrawlSchedule: "0 2 * * *",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	r := httptest.NewRequest(http.MethodPut, "/api/sources/"+itoa(id), bytes.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var updated db.Source
+	if err := json.NewDecoder(w.Body).Decode(&updated); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if updated.Name != "New Docs" {
+		t.Errorf("expected updated name, got %q", updated.Name)
+	}
+	if updated.Type != "web" {
+		t.Errorf("expected type to remain web, got %q", updated.Type)
+	}
+	if updated.URL != "https://new.example.com" {
+		t.Errorf("expected updated URL, got %q", updated.URL)
+	}
+	if updated.IncludePath != "https://new.example.com/guide/" {
+		t.Errorf("expected updated include path, got %q", updated.IncludePath)
+	}
+	if updated.CrawlSchedule != "0 2 * * *" {
+		t.Errorf("expected updated crawl schedule, got %q", updated.CrawlSchedule)
+	}
+	if updated.PageCount != 7 {
+		t.Errorf("expected page count to remain 7, got %d", updated.PageCount)
+	}
+	if updated.LastCrawled == nil {
+		t.Errorf("expected last crawled to remain set")
+	}
+}
+
+func TestUpdateSource_NotFound(t *testing.T) {
+	store := openTestStore(t)
+	srv := api.NewServer(store, nil, nil, make([]byte, 32))
+	body, _ := json.Marshal(db.Source{Name: "Missing", Type: "web", URL: "https://example.com"})
+
+	r := httptest.NewRequest(http.MethodPut, "/api/sources/9999", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateSource_RejectsDangerousSchemes(t *testing.T) {
+	store := openTestStore(t)
+	id, err := store.InsertSource(db.Source{Name: "Docs", Type: "web", URL: "https://example.com"})
+	if err != nil {
+		t.Fatalf("InsertSource: %v", err)
+	}
+	srv := api.NewServer(store, nil, nil, make([]byte, 32))
+	body, _ := json.Marshal(db.Source{Name: "Docs", Type: "web", URL: "javascript:alert(1)"})
+
+	r := httptest.NewRequest(http.MethodPut, "/api/sources/"+itoa(id), bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestTriggerCrawl_SourceNotFound(t *testing.T) {
 	store := openTestStore(t)
 	srv := api.NewServer(store, nil, nil, make([]byte, 32))

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -85,6 +85,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (s *Server) routes() {
 	s.mux.HandleFunc("GET /api/sources", s.listSources)
 	s.mux.HandleFunc("POST /api/sources", s.createSource)
+	s.mux.HandleFunc("PUT /api/sources/{id}", s.updateSource)
 	s.mux.HandleFunc("DELETE /api/sources/{id}", s.deleteSource)
 	s.mux.HandleFunc("POST /api/sources/{id}/crawl", s.triggerCrawl)
 	s.mux.HandleFunc("GET /api/search", s.searchHandler)
@@ -144,7 +145,7 @@ func securityMiddleware(next http.Handler) http.Handler {
 			if isLoopbackOrigin(origin) {
 				h.Set("Access-Control-Allow-Origin", origin)
 				h.Set("Vary", "Origin")
-				h.Set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
+				h.Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
 				h.Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
 			}
 		}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -158,6 +158,28 @@ func (s *Store) DeleteSource(id int64) error {
 	return nil
 }
 
+// UpdateSourceConfig updates editable source configuration fields.
+// It intentionally leaves type, auth, crawl progress, and timestamps unchanged.
+func (s *Store) UpdateSourceConfig(id int64, src Source) error {
+	res, err := s.db.Exec(
+		`UPDATE sources
+		 SET name = ?, url = ?, repo = ?, branch = ?, base_url = ?, space_key = ?, crawl_schedule = ?, include_path = ?
+		 WHERE id = ?`,
+		src.Name, src.URL, src.Repo, src.Branch, src.BaseURL, src.SpaceKey, src.CrawlSchedule, src.IncludePath, id,
+	)
+	if err != nil {
+		return fmt.Errorf("update source config %d: %w", id, err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("update source config %d rows affected: %w", id, err)
+	}
+	if n == 0 {
+		return fmt.Errorf("source %d: %w", id, ErrNotFound)
+	}
+	return nil
+}
+
 // UpdateSourcePageCount updates the page_count for a source.
 func (s *Store) UpdateSourcePageCount(id int64, count int) error {
 	_, err := s.db.Exec(

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -132,6 +132,68 @@ func TestDeleteSource(t *testing.T) {
 	}
 }
 
+func TestUpdateSourceConfig(t *testing.T) {
+	store := testutil.OpenStore(t)
+
+	id, err := store.InsertSource(db.Source{
+		Name:          "Original",
+		Type:          "web",
+		URL:           "https://old.example.com",
+		CrawlSchedule: "0 1 * * *",
+	})
+	if err != nil {
+		t.Fatalf("InsertSource: %v", err)
+	}
+	if err := store.UpdateSourcePageCount(id, 12); err != nil {
+		t.Fatalf("UpdateSourcePageCount: %v", err)
+	}
+
+	err = store.UpdateSourceConfig(id, db.Source{
+		Name:          "Updated",
+		Type:          "github_repo",
+		URL:           "https://new.example.com",
+		Repo:          "owner/repo",
+		Branch:        "develop",
+		IncludePath:   "docs/",
+		CrawlSchedule: "0 2 * * *",
+	})
+	if err != nil {
+		t.Fatalf("UpdateSourceConfig: %v", err)
+	}
+
+	src, err := store.GetSource(id)
+	if err != nil {
+		t.Fatalf("GetSource: %v", err)
+	}
+	if src.Name != "Updated" {
+		t.Errorf("expected name to update, got %q", src.Name)
+	}
+	if src.Type != "web" {
+		t.Errorf("expected type to remain web, got %q", src.Type)
+	}
+	if src.URL != "https://new.example.com" {
+		t.Errorf("expected URL to update, got %q", src.URL)
+	}
+	if src.Repo != "owner/repo" {
+		t.Errorf("expected repo to update, got %q", src.Repo)
+	}
+	if src.Branch != "develop" {
+		t.Errorf("expected branch to update, got %q", src.Branch)
+	}
+	if src.IncludePath != "docs/" {
+		t.Errorf("expected include path to update, got %q", src.IncludePath)
+	}
+	if src.CrawlSchedule != "0 2 * * *" {
+		t.Errorf("expected crawl schedule to update, got %q", src.CrawlSchedule)
+	}
+	if src.PageCount != 12 {
+		t.Errorf("expected page count to remain 12, got %d", src.PageCount)
+	}
+	if src.LastCrawled == nil {
+		t.Errorf("expected last crawled to remain set")
+	}
+}
+
 func TestUpdateSourcePageCount(t *testing.T) {
 	store := testutil.OpenStore(t)
 

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -1,9 +1,15 @@
+function blankSource(type = 'web') {
+  return { Name: '', Type: type, URL: '', Repo: '', Branch: '', IncludePath: '', CrawlSchedule: '' }
+}
+
 function app() {
   return {
     view: 'sources',
     sources: [],
     showAddForm: false,
-    newSource: { Name: '', Type: 'web', URL: '', Repo: '', IncludePath: '', CrawlSchedule: '' },
+    newSource: blankSource(),
+    editingSourceId: null,
+    editSource: blankSource(),
     deviceCodePending: null,
     pollInterval: null,
     refreshInterval: null,
@@ -62,10 +68,45 @@ function app() {
         })
         if (!r.ok) { alert('Failed to add source: ' + await r.text()); return }
         this.showAddForm = false
-        this.newSource = { Name: '', Type: 'web', URL: '', Repo: '', IncludePath: '', CrawlSchedule: '' }
+        this.newSource = blankSource()
         await this.loadSources()
       } catch(e) {
         console.error('addSource:', e)
+      }
+    },
+
+    startEditSource(src) {
+      this.showAddForm = false
+      this.editingSourceId = src.ID
+      this.editSource = {
+        Name: src.Name || '',
+        Type: src.Type || 'web',
+        URL: src.URL || '',
+        Repo: src.Repo || '',
+        Branch: src.Branch || '',
+        IncludePath: src.IncludePath || '',
+        CrawlSchedule: src.CrawlSchedule || ''
+      }
+    },
+
+    cancelEditSource() {
+      this.editingSourceId = null
+      this.editSource = blankSource()
+    },
+
+    async updateSource(id) {
+      const body = { ...this.editSource }
+      try {
+        const r = await fetch(`/api/sources/${id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body)
+        })
+        if (!r.ok) { alert('Failed to update source: ' + await r.text()); return }
+        this.cancelEditSource()
+        await this.loadSources()
+      } catch(e) {
+        console.error('updateSource:', e)
       }
     },
 
@@ -200,6 +241,18 @@ function app() {
     sourceTypeName(type) {
       const map = { web: 'Web', github_wiki: 'GitHub Wiki', github_repo: 'GitHub Repo', azure_devops: 'Azure DevOps' }
       return map[type] || type
+    },
+
+    sourceDisplayURL(src) {
+      if (!src) return ''
+      if (src.Type === 'github_wiki' && src.Repo) return `https://github.com/${src.Repo}/wiki`
+      if (src.Type === 'github_repo' && src.Repo) {
+        const branch = src.Branch || 'main'
+        const includePath = (src.IncludePath || '').replace(/^\/+|\/+$/g, '')
+        const base = `https://github.com/${src.Repo}/tree/${branch}`
+        return includePath ? `${base}/${includePath}` : base
+      }
+      return src.URL || src.BaseURL || ''
     },
 
     formatDate(ts) {

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -107,12 +107,56 @@
             </div>
             <div class="actions">
               <button class="secondary" @click="connectAuth(src.ID, src.Type, src.Name)" x-show="src.Type !== 'web'">Connect</button>
+              <button class="secondary" @click="startEditSource(src)" x-show="editingSourceId !== src.ID">Edit</button>
               <button class="secondary" @click="crawlNow(src.ID)" :disabled="isCrawling(src)">Crawl Now</button>
               <button class="danger" @click="deleteSource(src.ID)">Remove</button>
             </div>
           </div>
-          <div class="muted" x-show="src.LastCrawled" x-text="'Last crawled: ' + formatDate(src.LastCrawled)"></div>
-          <div class="muted" x-show="!src.LastCrawled && !isCrawling(src)">Never crawled</div>
+          <div x-show="editingSourceId === src.ID" class="source-edit-form">
+            <select x-model="editSource.Type" disabled>
+              <option value="web">Web</option>
+              <option value="github_wiki">GitHub Wiki</option>
+              <option value="github_repo">GitHub Repo</option>
+              <option value="azure_devops">Azure DevOps Wiki</option>
+            </select>
+            <input type="text" x-model="editSource.Name" placeholder="Source name" />
+            <template x-if="editSource.Type === 'web'">
+              <input type="url" x-model="editSource.URL" placeholder="https://docs.example.com" />
+            </template>
+            <template x-if="editSource.Type === 'web'">
+              <input type="url" x-model="editSource.IncludePath"
+                     placeholder="Restrict to path prefix (optional, e.g. https://docs.example.com/guide/)" />
+            </template>
+            <template x-if="editSource.Type === 'github_wiki'">
+              <input type="text" x-model="editSource.Repo" placeholder="owner/repo" />
+            </template>
+            <template x-if="editSource.Type === 'github_repo'">
+              <input type="text" x-model="editSource.Repo" placeholder="owner/repo" />
+            </template>
+            <template x-if="editSource.Type === 'github_repo'">
+              <input type="text" x-model="editSource.Branch" placeholder="Branch (default: main)" />
+            </template>
+            <template x-if="editSource.Type === 'github_repo'">
+              <input type="text" x-model="editSource.IncludePath"
+                     placeholder="Subfolder prefix (optional, e.g. docs/)" />
+            </template>
+            <template x-if="editSource.Type === 'azure_devops'">
+              <input type="url" x-model="editSource.URL" placeholder="https://dev.azure.com/org/project" />
+            </template>
+            <input type="text" x-model="editSource.CrawlSchedule" placeholder="Cron schedule (e.g. 0 2 * * *)" />
+            <div class="actions">
+              <button @click="updateSource(src.ID)">Save</button>
+              <button class="secondary" @click="cancelEditSource()">Cancel</button>
+            </div>
+          </div>
+          <div x-show="editingSourceId !== src.ID">
+            <div class="muted source-meta" x-show="sourceDisplayURL(src)">
+              <span x-text="sourceTypeName(src.Type) + ': '"></span>
+              <a :href="safeHref(sourceDisplayURL(src))" target="_blank" rel="noopener noreferrer" x-text="sourceDisplayURL(src)"></a>
+            </div>
+            <div class="muted" x-show="src.LastCrawled" x-text="'Last crawled: ' + formatDate(src.LastCrawled)"></div>
+            <div class="muted" x-show="!src.LastCrawled && !isCrawling(src)">Never crawled</div>
+          </div>
         </div>
       </template>
     </div>

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -45,6 +45,10 @@ h2 { font-size: 1.1rem; font-weight: 600; }
 
 .muted { color: var(--muted); font-size: 0.875rem; }
 .actions { display: flex; gap: 0.5rem; flex-wrap: wrap; }
+.source-edit-form { border-top: 1px solid var(--border); margin-top: 0.75rem; padding-top: 1rem; }
+.source-meta { margin-bottom: 0.25rem; overflow-wrap: anywhere; }
+.source-meta a { color: inherit; text-decoration: none; }
+.source-meta a:hover { color: var(--accent-hover); text-decoration: underline; }
 
 .device-code-box { background: var(--bg); border: 1px solid var(--border); border-radius: 6px; padding: 1rem; margin-top: 1rem; }
 .device-code { font-size: 2rem; font-weight: 700; letter-spacing: 0.25em; color: var(--accent); margin: 0.5rem 0; }


### PR DESCRIPTION
## Summary

Adds source editing from the web UI and persists source configuration changes through a new update endpoint.

## Changes

- Add `PUT /api/sources/{id}` for updating editable source config while keeping the existing source type fixed.
- Add DB update support for source config fields without touching auth, crawl metadata, or timestamps.
- Add an inline Edit flow to the Sources UI.
- Show a muted provider/link row above the Last crawled timestamp.

## Validation

- `node --check web/static/app.js`
- `CGO_ENABLED=1 go test -tags sqlite_fts5 ./...`
- Browser smoke-tested the edit flow locally via Playwright.
