### PR TITLE
feat: support multiple source include paths

### DIFF
--- a/cmd/documcp/main.go
+++ b/cmd/documcp/main.go
@@ -46,6 +46,10 @@ func main() {
 		os.Exit(1)
 	}
 	defer store.Close()
+	if err := crawler.SyncConfigSources(store, cfg); err != nil {
+		slog.Error("sync config sources", "err", err)
+		os.Exit(1)
+	}
 
 	modelPath := getenv("DOCUMCP_MODEL_PATH", "/app/models/all-MiniLM-L6-v2")
 	var embedder *embed.Embedder
@@ -72,6 +76,10 @@ func main() {
 	// Reload config on file change. Non-fatal if watch cannot be established.
 	watcher, err := config.Watch(cfgPath, func(newCfg *config.Config) {
 		slog.Info("config reloaded")
+		if err := crawler.SyncConfigSources(store, newCfg); err != nil {
+			slog.Error("sync config sources", "err", err)
+			return
+		}
 		scheduler.Load(newCfg)
 	})
 	if err != nil {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -7,7 +7,9 @@ sources:
   # - name: ArgoCD Operator Manual
   #   type: web
   #   url: https://argo-cd.readthedocs.io/en/stable/
-  #   include_path: https://argo-cd.readthedocs.io/en/stable/operator-manual/
+  #   include_paths:
+  #     - https://argo-cd.readthedocs.io/en/stable/operator-manual/
+  #     - https://argo-cd.readthedocs.io/en/stable/user-guide/
   #   crawl_schedule: "@weekly"
 
   # GitHub wiki (public or with a fine-grained PAT for private):
@@ -21,7 +23,9 @@ sources:
   #   type: github_repo
   #   repo: owner/repo
   #   branch: main
-  #   include_path: docs/
+  #   include_paths:
+  #     - docs/
+  #     - help/tests/
   #   crawl_schedule: "@daily"
 
   # Azure DevOps wiki (Microsoft device code flow):

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -8,8 +8,8 @@ sources:
   #   type: web
   #   url: https://argo-cd.readthedocs.io/en/stable/
   #   include_paths:
-  #     - https://argo-cd.readthedocs.io/en/stable/operator-manual/
-  #     - https://argo-cd.readthedocs.io/en/stable/user-guide/
+  #     - operator-manual/
+  #     - user-guide/
   #   crawl_schedule: "@weekly"
 
   # GitHub wiki (public or with a fine-grained PAT for private):

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,7 +15,8 @@ Provide a `config.yaml` when you want to declare sources and crawl schedules in 
 | `sources[].name` | Display name for the source |
 | `sources[].type` | `web`, `github_wiki`, `github_repo`, or `azure_devops` |
 | `sources[].url` | Base URL (web and Azure DevOps sources) |
-| `sources[].include_path` | For `web`: restricts crawling to a URL prefix (same origin required). For `github_repo`: restricts indexing to a subfolder (e.g. `docs/`). `..` segments are rejected. |
+| `sources[].include_path` | Legacy single path filter. Prefer `include_paths` for new config. |
+| `sources[].include_paths` | For `web`: only same-origin URLs under these prefixes are indexed. For `github_repo`: only files under these repository folders are indexed. Empty means the current whole-source behavior. |
 | `sources[].repo` | `owner/repo` (GitHub Wiki and GitHub Repo sources) |
 | `sources[].branch` | Branch name for `github_repo` sources (default: `main`) |
 | `sources[].crawl_schedule` | Cron expression, e.g. `0 2 * * *` or `@weekly` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,7 +16,7 @@ Provide a `config.yaml` when you want to declare sources and crawl schedules in 
 | `sources[].type` | `web`, `github_wiki`, `github_repo`, or `azure_devops` |
 | `sources[].url` | Base URL (web and Azure DevOps sources) |
 | `sources[].include_path` | Legacy single path filter. Prefer `include_paths` for new config. |
-| `sources[].include_paths` | For `web`: only same-origin URLs under these prefixes are indexed. For `github_repo`: only files under these repository folders are indexed. Empty means the current whole-source behavior. |
+| `sources[].include_paths` | For `web`: only same-origin URLs under these prefixes are indexed. Entries may be relative paths such as `/guides/` or full same-origin URLs. For `github_repo`: only files under these repository folders are indexed. Empty means the current whole-source behavior. |
 | `sources[].repo` | `owner/repo` (GitHub Wiki and GitHub Repo sources) |
 | `sources[].branch` | Branch name for `github_repo` sources (default: `main`) |
 | `sources[].crawl_schedule` | Cron expression, e.g. `0 2 * * *` or `@weekly` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,7 @@
 
 DocuMcp reads its configuration from an optional YAML file and a small set of environment variables. If no config file is present, the server starts with built-in defaults (`port: 8080`, `data_dir: /app/data`, no declarative sources) and all source management happens through the Web UI — those sources persist in the SQLite database under `data_dir`.
 
-Provide a `config.yaml` when you want to declare sources and crawl schedules in version control. The file watcher reloads it on save, so changes take effect without a restart. UI-added sources are stored in the database, not written back to YAML.
+Provide a `config.yaml` when you want to declare sources and crawl schedules in version control. Config-declared sources are mirrored into SQLite so they appear in the Web UI and API source listings. The file watcher reloads YAML on save, so source changes take effect without a restart. UI-added sources are stored in the database, not written back to YAML.
 
 `DOCUMCP_CONFIG` lets you override the path. When it is set, the file must exist (typos fail loudly); when it is unset, a missing file silently falls back to defaults.
 

--- a/docs/plans/2026-05-06-multiple-include-paths-design.md
+++ b/docs/plans/2026-05-06-multiple-include-paths-design.md
@@ -1,0 +1,239 @@
+# Design: Multiple Source Path Prefix Filters (`include_paths`)
+
+**Date:** 2026-05-06
+**Status:** Approved
+
+## Problem
+
+Sources can currently be scoped with one `include_path`. For web sources this limits crawling to one same-origin URL prefix. For `github_repo` sources this limits indexing to one repository subfolder. Some documentation sets are split across multiple relevant sections, so one source either has to crawl too broadly or be duplicated into several sources.
+
+The existing name also reads like an additive option. In practice it is a scope filter: only matching pages or files are indexed.
+
+## Solution
+
+Add `include_paths` as the canonical multi-path field for `web` and `github_repo` sources. Keep the existing `include_path` field as a backwards-compatible single-path alias for existing YAML files, database rows, API clients, and UI-created records.
+
+```yaml
+sources:
+  - name: Product Docs
+    type: web
+    url: https://docs.example.com/
+    include_paths:
+      - https://docs.example.com/guides/
+      - https://docs.example.com/reference/
+    crawl_schedule: "@weekly"
+
+  - name: Repo Docs
+    type: github_repo
+    repo: owner/repo
+    branch: main
+    include_paths:
+      - docs/
+      - examples/
+    crawl_schedule: "@daily"
+```
+
+When `include_paths` contains multiple entries, a page or file is indexed if it matches any configured prefix. Empty `include_paths` preserves current behavior.
+
+## Field Semantics
+
+### Canonical Field
+
+`include_paths` is the new primary field:
+
+```go
+IncludePaths []string `yaml:"include_paths,omitempty"`
+```
+
+`include_path` remains available:
+
+```go
+IncludePath string `yaml:"include_path,omitempty"`
+```
+
+The system accepts three shapes:
+
+- `include_path` only: existing single-path behavior.
+- `include_paths` only: new multi-path behavior.
+- Both fields: union the values, deduplicate after normalization, and preserve first-seen order.
+
+DB/API structs should also gain `IncludePaths []string` while retaining `IncludePath string`.
+
+### Normalization
+
+Add a focused helper that returns normalized include paths for adapters and persistence. It should:
+
+- Combine `IncludePath` and `IncludePaths`.
+- Trim whitespace.
+- Drop empty entries.
+- Deduplicate while preserving order.
+- Return an empty slice, not `nil`.
+
+Normalization should not silently convert invalid values into valid ones. Adapter-specific validation still owns source-type rules.
+
+## Web Source Behavior
+
+For `type: web`:
+
+- Each include path must parse as an HTTP(S) URL with a host.
+- Each include path must share origin with the source `url`.
+- The crawler keeps sitemap URLs whose path matches any include prefix.
+- If no include paths are configured, the current fallback remains: filter by the source URL path.
+
+Example:
+
+```yaml
+- name: Framework Docs
+  type: web
+  url: https://docs.example.com/
+  include_paths:
+    - https://docs.example.com/tutorials/
+    - https://docs.example.com/api/
+```
+
+This indexes URLs under `/tutorials/` or `/api/`, not the rest of the site.
+
+## GitHub Repo Source Behavior
+
+For `type: github_repo`:
+
+- Each include path is a repository-relative folder prefix.
+- Leading slashes may be normalized away as they are today.
+- Non-empty prefixes should compare with a trailing slash to avoid accidental partial matches.
+- Any entry containing `..` traversal is rejected before fetching the tarball.
+- Files are indexed when their repo-relative path matches any normalized prefix.
+- If no include paths are configured, the whole repository is eligible.
+
+Example:
+
+```yaml
+- name: Repo Docs
+  type: github_repo
+  repo: owner/repo
+  branch: main
+  include_paths:
+    - docs/
+    - examples/tutorials/
+```
+
+This indexes Markdown, MDX, and text files under those folders only.
+
+## Persistence
+
+Add a new SQLite column:
+
+```sql
+include_paths TEXT NOT NULL DEFAULT '[]'
+```
+
+Store `include_paths` as JSON text. Keep the existing `include_path` column.
+
+On read:
+
+- Decode `include_paths`.
+- Combine it with `include_path` through the normalization helper.
+- Populate `Source.IncludePaths` with the full normalized list.
+- Keep `Source.IncludePath` populated with the legacy single value. If the legacy column is empty and the normalized list has entries, use the first entry.
+
+On insert/update:
+
+- Store the normalized list in `include_paths`.
+- Store the first normalized entry in `include_path`, or `""` if the list is empty.
+
+This keeps old clients working while making the multi-path field authoritative for new code.
+
+## API And MCP Shape
+
+JSON source payloads should accept and return both fields:
+
+```json
+{
+  "Name": "Product Docs",
+  "Type": "web",
+  "URL": "https://docs.example.com/",
+  "IncludePaths": [
+    "https://docs.example.com/guides/",
+    "https://docs.example.com/reference/"
+  ],
+  "IncludePath": "https://docs.example.com/guides/"
+}
+```
+
+Validation should check every entry in `IncludePaths`, plus the legacy `IncludePath` when supplied.
+
+MCP source listings should add `includePaths` while keeping `includePath` for compatibility.
+
+## Web UI
+
+The Web UI must be updated as part of this feature.
+
+Replace the single include-path input in add/edit forms for `web` and `github_repo` sources with a compact multi-entry control:
+
+- Group label: **Crawl only these paths**
+- Button: **Add path**
+- Web placeholder: `https://docs.example.com/guides/`
+- GitHub repo placeholder: `docs/`
+
+Helper text for web sources:
+
+> Only same-site URLs under these prefixes will be indexed. Leave empty to use the source URL path.
+
+Helper text for GitHub repo sources:
+
+> Only files under these repository folders will be indexed. Leave empty to index the whole repo.
+
+The UI should:
+
+- Initialize add forms with `IncludePaths: []`.
+- Initialize edit forms from `IncludePaths`, falling back to `[IncludePath]` for old records.
+- Send `IncludePaths` in create/update payloads.
+- Also send `IncludePath` as the first path for legacy server compatibility during the transition.
+- Display multiple scoped paths clearly in source metadata, without implying they are additional crawl roots.
+
+## Implementation Notes
+
+Likely files to touch:
+
+- `internal/config/config.go`: add `IncludePaths` to `SourceConfig`.
+- `internal/db/schema.go`: add `include_paths` to the base schema.
+- `internal/db/db.go`: add migration, JSON encode/decode, insert/select/update support, and `Source.IncludePaths`.
+- `internal/crawler/crawler.go`: forward `IncludePaths` in `sourceToConfig`.
+- `internal/api/handlers.go`: validate every configured web URL path entry.
+- `internal/mcp/tools.go`: expose `includePaths`.
+- `internal/adapter/web/web.go`: evaluate multiple URL path prefixes.
+- `internal/adapter/githubrepo/githubrepo.go`: evaluate multiple repo folder prefixes and validate traversal per entry.
+- `web/static/app.js`: manage path arrays in add/edit state, payloads, and source display.
+- `web/static/index.html`: replace the single input with multi-entry controls and clearer helper text.
+- `docs/configuration.md`, `docs/sources.md`, and `config.example.yaml`: document `include_paths` and clarify that these paths are filters.
+
+## Testing
+
+Add or update tests for:
+
+- YAML loading with legacy `include_path`, new `include_paths`, and both fields together.
+- DB insert/list/get/update preserving multiple paths and populating legacy `IncludePath`.
+- API create/update validation across multiple web include paths.
+- Web adapter matching any of several same-origin URL prefixes.
+- Web adapter rejecting any cross-origin or malformed include path.
+- GitHub repo adapter matching any of several subfolder prefixes.
+- GitHub repo adapter rejecting `..` traversal in any include path.
+- `sourceToConfig` forwarding both legacy and multi-path fields.
+- MCP source conversion returning both `includePath` and `includePaths`.
+
+Before PR, run:
+
+```bash
+gofmt -w .
+CGO_ENABLED=1 go vet -tags sqlite_fts5 ./...
+CGO_ENABLED=1 go test -tags sqlite_fts5 -race ./...
+```
+
+For the UI, run the app locally and manually verify add/edit forms for both `web` and `github_repo` sources show the new wording, preserve multiple rows, and submit the expected payload.
+
+## Non-Goals
+
+- Do not remove `include_path`.
+- Do not change GitHub Wiki or Azure DevOps source scoping.
+- Do not introduce exclusion paths.
+- Do not make web include paths cross-origin crawl roots.
+- Do not write UI-managed sources back to YAML.

--- a/docs/plans/2026-05-06-multiple-include-paths-impl.md
+++ b/docs/plans/2026-05-06-multiple-include-paths-impl.md
@@ -1,0 +1,1203 @@
+# Multiple Include Paths Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `include_paths` so web and GitHub repo sources can be scoped to multiple path prefixes while preserving `include_path` compatibility.
+
+**Architecture:** Add `IncludePaths []string` beside the existing `IncludePath string`, normalize both fields into one ordered set, and store the list in a new SQLite JSON-text column. Adapters consume normalized path lists and match pages/files against any configured prefix. The Web UI replaces the single ambiguous include-path input with a multi-entry "Crawl only these paths" control.
+
+**Tech Stack:** Go 1.26, SQLite with JSON encoded text columns, YAML via `gopkg.in/yaml.v3`, Alpine.js static UI.
+
+---
+
+## File Structure
+
+- `internal/config/config.go`: add `IncludePaths` to `SourceConfig`.
+- `internal/config/config_test.go`: cover YAML loading for legacy and multi-path fields.
+- `internal/sourcepaths/sourcepaths.go`: new small helper package for combining/deduping path lists.
+- `internal/sourcepaths/sourcepaths_test.go`: unit tests for helper behavior.
+- `internal/db/schema.go`: add `include_paths TEXT NOT NULL DEFAULT '[]'`.
+- `internal/db/db.go`: add `Source.IncludePaths`, migration, JSON encode/decode helpers, and query updates.
+- `internal/db/db_test.go`: cover insert/get/list/update compatibility.
+- `internal/crawler/crawler.go` and `internal/crawler/crawler_internal_test.go`: forward `IncludePaths`.
+- `internal/api/handlers.go` and `internal/api/handlers_test.go`: validate every path entry and return both fields.
+- `internal/mcp/tools.go` and `internal/mcp/server_test.go` or a focused new internal MCP test: expose `includePaths`.
+- `internal/adapter/web/web.go` and `internal/adapter/web/web_test.go`: parse/validate multiple URL prefixes and match any.
+- `internal/adapter/githubrepo/githubrepo.go` and `internal/adapter/githubrepo/githubrepo_test.go`: normalize/validate multiple repo prefixes and match any.
+- `web/static/app.js`: manage path arrays, request payloads, and display text.
+- `web/static/index.html`: add multi-entry controls and clearer helper text.
+- `web/static/style.css`: add modest styles if needed for row controls.
+- `docs/configuration.md`, `docs/sources.md`, `config.example.yaml`: document `include_paths`.
+
+## Task 1: Config Model And Normalization Helper
+
+**Files:**
+- Modify: `internal/config/config.go`
+- Create: `internal/sourcepaths/sourcepaths.go`
+- Create: `internal/sourcepaths/sourcepaths_test.go`
+- Test: `internal/config/config_test.go`
+
+- [ ] **Step 1.1: Write normalization helper tests**
+
+Create `internal/sourcepaths/sourcepaths_test.go`:
+
+```go
+package sourcepaths
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNormalize_CombinesLegacyAndList(t *testing.T) {
+	got := Normalize(" docs/ ", []string{"examples/", "", "docs/", " api/ "})
+	want := []string{"docs/", "examples/", "api/"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Normalize() = %#v, want %#v", got, want)
+	}
+}
+
+func TestNormalize_EmptyReturnsEmptySlice(t *testing.T) {
+	got := Normalize("", nil)
+	if got == nil {
+		t.Fatal("Normalize returned nil, want empty slice")
+	}
+	if len(got) != 0 {
+		t.Fatalf("Normalize length = %d, want 0", len(got))
+	}
+}
+
+func TestFirst_ReturnsFirstOrEmpty(t *testing.T) {
+	if got := First([]string{"docs/", "api/"}); got != "docs/" {
+		t.Fatalf("First() = %q, want docs/", got)
+	}
+	if got := First(nil); got != "" {
+		t.Fatalf("First(nil) = %q, want empty", got)
+	}
+}
+```
+
+- [ ] **Step 1.2: Run helper tests and verify they fail**
+
+Run:
+
+```bash
+CGO_ENABLED=1 go test -tags sqlite_fts5 ./internal/sourcepaths
+```
+
+Expected: fail because `internal/sourcepaths` does not exist.
+
+- [ ] **Step 1.3: Implement the helper**
+
+Create `internal/sourcepaths/sourcepaths.go`:
+
+```go
+package sourcepaths
+
+import "strings"
+
+// Normalize combines the legacy single path with the multi-path list.
+// It trims blanks, drops empty entries, and deduplicates in first-seen order.
+func Normalize(legacy string, paths []string) []string {
+	out := make([]string, 0, len(paths)+1)
+	seen := make(map[string]struct{}, len(paths)+1)
+	for _, p := range append([]string{legacy}, paths...) {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if _, ok := seen[p]; ok {
+			continue
+		}
+		seen[p] = struct{}{}
+		out = append(out, p)
+	}
+	return out
+}
+
+func First(paths []string) string {
+	if len(paths) == 0 {
+		return ""
+	}
+	return paths[0]
+}
+```
+
+- [ ] **Step 1.4: Run helper tests and verify they pass**
+
+Run:
+
+```bash
+CGO_ENABLED=1 go test -tags sqlite_fts5 ./internal/sourcepaths
+```
+
+Expected: pass.
+
+- [ ] **Step 1.5: Add `IncludePaths` to config**
+
+In `internal/config/config.go`, update `SourceConfig`:
+
+```go
+URL          string   `yaml:"url,omitempty"`
+IncludePath  string   `yaml:"include_path,omitempty"`
+IncludePaths []string `yaml:"include_paths,omitempty"`
+Auth         string   `yaml:"auth,omitempty"`
+```
+
+- [ ] **Step 1.6: Add YAML loading test**
+
+Append to `internal/config/config_test.go`:
+
+```go
+func TestLoadConfig_IncludePaths(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "include-paths.yaml")
+	data := []byte(`sources:
+  - name: Docs
+    type: web
+    url: https://docs.example.com/
+    include_path: https://docs.example.com/legacy/
+    include_paths:
+      - https://docs.example.com/guides/
+      - https://docs.example.com/reference/
+`)
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("write temp config: %v", err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	src := cfg.Sources[0]
+	if src.IncludePath != "https://docs.example.com/legacy/" {
+		t.Fatalf("IncludePath = %q", src.IncludePath)
+	}
+	want := []string{"https://docs.example.com/guides/", "https://docs.example.com/reference/"}
+	if !reflect.DeepEqual(src.IncludePaths, want) {
+		t.Fatalf("IncludePaths = %#v, want %#v", src.IncludePaths, want)
+	}
+}
+```
+
+Add `reflect` to the imports.
+
+- [ ] **Step 1.7: Run config tests**
+
+Run:
+
+```bash
+CGO_ENABLED=1 go test -tags sqlite_fts5 ./internal/config
+```
+
+Expected: pass.
+
+- [ ] **Step 1.8: Commit**
+
+```bash
+git add internal/config/config.go internal/config/config_test.go internal/sourcepaths/sourcepaths.go internal/sourcepaths/sourcepaths_test.go
+git commit -m "feat(config): add include_paths model"
+```
+
+## Task 2: Persist Multiple Include Paths
+
+**Files:**
+- Modify: `internal/db/schema.go`
+- Modify: `internal/db/db.go`
+- Modify: `internal/db/db_test.go`
+
+- [ ] **Step 2.1: Add failing DB tests**
+
+In `internal/db/db_test.go`, add:
+
+```go
+func TestInsertSource_PersistsIncludePaths(t *testing.T) {
+	store := testutil.OpenStore(t)
+
+	id, err := store.InsertSource(db.Source{
+		Name:         "Docs",
+		Type:         "web",
+		URL:          "https://docs.example.com",
+		IncludePaths: []string{"https://docs.example.com/guides/", "https://docs.example.com/reference/"},
+	})
+	if err != nil {
+		t.Fatalf("InsertSource: %v", err)
+	}
+	got, err := store.GetSource(id)
+	if err != nil {
+		t.Fatalf("GetSource: %v", err)
+	}
+	want := []string{"https://docs.example.com/guides/", "https://docs.example.com/reference/"}
+	if !reflect.DeepEqual(got.IncludePaths, want) {
+		t.Fatalf("IncludePaths = %#v, want %#v", got.IncludePaths, want)
+	}
+	if got.IncludePath != want[0] {
+		t.Fatalf("IncludePath = %q, want first path %q", got.IncludePath, want[0])
+	}
+}
+
+func TestInsertSource_LegacyIncludePathPopulatesIncludePaths(t *testing.T) {
+	store := testutil.OpenStore(t)
+
+	id, err := store.InsertSource(db.Source{
+		Name:        "Docs",
+		Type:        "github_repo",
+		Repo:        "owner/repo",
+		IncludePath: "docs/",
+	})
+	if err != nil {
+		t.Fatalf("InsertSource: %v", err)
+	}
+	got, err := store.GetSource(id)
+	if err != nil {
+		t.Fatalf("GetSource: %v", err)
+	}
+	if !reflect.DeepEqual(got.IncludePaths, []string{"docs/"}) {
+		t.Fatalf("IncludePaths = %#v, want [docs/]", got.IncludePaths)
+	}
+}
+```
+
+Add `reflect` to imports if absent.
+
+- [ ] **Step 2.2: Run DB tests and verify they fail**
+
+Run:
+
+```bash
+CGO_ENABLED=1 go test -tags sqlite_fts5 ./internal/db -run 'TestInsertSource_.*IncludePath'
+```
+
+Expected: fail because `db.Source.IncludePaths` does not exist.
+
+- [ ] **Step 2.3: Add schema and migration**
+
+In `internal/db/schema.go`, add `include_paths` after `include_path`:
+
+```sql
+    include_path   TEXT NOT NULL DEFAULT '',
+    include_paths  TEXT NOT NULL DEFAULT '[]',
+```
+
+In `internal/db/db.go` `Open`, add:
+
+```go
+_, _ = db.Exec(`ALTER TABLE sources ADD COLUMN include_paths TEXT NOT NULL DEFAULT '[]'`)
+```
+
+- [ ] **Step 2.4: Add DB struct field and JSON helpers**
+
+In `internal/db/db.go`, add to `Source`:
+
+```go
+IncludePath    string
+IncludePaths   []string
+```
+
+Add helpers near `Source` or before `InsertSource`:
+
+```go
+func sourceIncludePaths(src Source) []string {
+	return sourcepaths.Normalize(src.IncludePath, src.IncludePaths)
+}
+
+func encodeIncludePaths(paths []string) (string, error) {
+	if paths == nil {
+		paths = []string{}
+	}
+	data, err := json.Marshal(paths)
+	if err != nil {
+		return "", fmt.Errorf("marshal include_paths: %w", err)
+	}
+	return string(data), nil
+}
+
+func decodeIncludePaths(raw string) ([]string, error) {
+	if raw == "" {
+		return []string{}, nil
+	}
+	var paths []string
+	if err := json.Unmarshal([]byte(raw), &paths); err != nil {
+		return nil, fmt.Errorf("unmarshal include_paths: %w", err)
+	}
+	if paths == nil {
+		paths = []string{}
+	}
+	return paths, nil
+}
+```
+
+Add import:
+
+```go
+"github.com/mathwro/DocuMcp/internal/sourcepaths"
+```
+
+- [ ] **Step 2.5: Update insert/select/update scans**
+
+Update `InsertSource` to compute normalized paths:
+
+```go
+paths := sourceIncludePaths(src)
+pathsJSON, err := encodeIncludePaths(paths)
+if err != nil {
+	return 0, err
+}
+legacyPath := sourcepaths.First(paths)
+```
+
+Then update the query:
+
+```go
+`INSERT INTO sources (name, type, url, repo, branch, base_url, space_key, auth, crawl_schedule, include_path, include_paths)
+ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+src.Name, src.Type, src.URL, src.Repo, src.Branch, src.BaseURL, src.SpaceKey, src.Auth, src.CrawlSchedule, legacyPath, pathsJSON,
+```
+
+Update both `SELECT` lists to include `include_paths` after `include_path`. Scan into local `includePathsJSON string`, then call:
+
+```go
+paths, err := decodeIncludePaths(includePathsJSON)
+if err != nil {
+	return nil, fmt.Errorf("decode source include paths: %w", err)
+}
+src.IncludePaths = sourcepaths.Normalize(src.IncludePath, paths)
+if src.IncludePath == "" {
+	src.IncludePath = sourcepaths.First(src.IncludePaths)
+}
+```
+
+Use the same logic in `ListSources` and `GetSource`, with error messages that include the operation.
+
+Update `UpdateSourceConfig` with normalized paths and query:
+
+```go
+paths := sourceIncludePaths(src)
+pathsJSON, err := encodeIncludePaths(paths)
+if err != nil {
+	return fmt.Errorf("update source config %d include paths: %w", id, err)
+}
+legacyPath := sourcepaths.First(paths)
+```
+
+```sql
+SET name = ?, url = ?, repo = ?, branch = ?, base_url = ?, space_key = ?, crawl_schedule = ?, include_path = ?, include_paths = ?
+```
+
+- [ ] **Step 2.6: Run DB tests**
+
+Run:
+
+```bash
+CGO_ENABLED=1 go test -tags sqlite_fts5 ./internal/db
+```
+
+Expected: pass.
+
+- [ ] **Step 2.7: Commit**
+
+```bash
+git add internal/db/schema.go internal/db/db.go internal/db/db_test.go
+git commit -m "feat(db): persist multiple include paths"
+```
+
+## Task 3: Forward And Expose Multiple Include Paths
+
+**Files:**
+- Modify: `internal/crawler/crawler.go`
+- Modify: `internal/crawler/crawler_internal_test.go`
+- Modify: `internal/mcp/tools.go`
+- Test: `internal/mcp`
+
+- [ ] **Step 3.1: Add crawler forwarding test**
+
+In `internal/crawler/crawler_internal_test.go`, add:
+
+```go
+func TestSourceToConfig_ForwardsIncludePaths(t *testing.T) {
+	got := sourceToConfig(db.Source{
+		Type:         "web",
+		URL:          "https://docs.example.com",
+		IncludePath:  "https://docs.example.com/legacy/",
+		IncludePaths: []string{"https://docs.example.com/guides/"},
+	})
+	if got.IncludePath != "https://docs.example.com/legacy/" {
+		t.Fatalf("IncludePath = %q", got.IncludePath)
+	}
+	if !reflect.DeepEqual(got.IncludePaths, []string{"https://docs.example.com/guides/"}) {
+		t.Fatalf("IncludePaths = %#v", got.IncludePaths)
+	}
+}
+```
+
+Add `reflect` to imports.
+
+- [ ] **Step 3.2: Run crawler test and verify it fails**
+
+Run:
+
+```bash
+CGO_ENABLED=1 go test -tags sqlite_fts5 ./internal/crawler -run TestSourceToConfig_ForwardsIncludePaths
+```
+
+Expected: fail because `SourceConfig.IncludePaths` is not forwarded.
+
+- [ ] **Step 3.3: Forward `IncludePaths`**
+
+In `internal/crawler/crawler.go`, add:
+
+```go
+IncludePaths:  src.IncludePaths,
+```
+
+beside `IncludePath`.
+
+- [ ] **Step 3.4: Expose MCP `includePaths`**
+
+In `internal/mcp/tools.go`, add to `sourceInfo`:
+
+```go
+IncludePaths []string `json:"includePaths,omitempty"`
+```
+
+In `toSourceInfo`, add:
+
+```go
+IncludePaths: s.IncludePaths,
+```
+
+- [ ] **Step 3.5: Run crawler and MCP tests**
+
+Run:
+
+```bash
+CGO_ENABLED=1 go test -tags sqlite_fts5 ./internal/crawler ./internal/mcp
+```
+
+Expected: pass.
+
+- [ ] **Step 3.6: Commit**
+
+```bash
+git add internal/crawler/crawler.go internal/crawler/crawler_internal_test.go internal/mcp/tools.go
+git commit -m "feat: expose multiple include paths"
+```
+
+## Task 4: API Validation And Round Trip
+
+**Files:**
+- Modify: `internal/api/handlers.go`
+- Modify: `internal/api/handlers_test.go`
+
+- [ ] **Step 4.1: Add API update test for multiple paths**
+
+In `internal/api/handlers_test.go`, add:
+
+```go
+func TestUpdateSource_IncludePaths(t *testing.T) {
+	store := openTestStore(t)
+	id, err := store.InsertSource(db.Source{
+		Name: "Docs",
+		Type: "web",
+		URL:  "https://docs.example.com",
+	})
+	if err != nil {
+		t.Fatalf("InsertSource: %v", err)
+	}
+
+	srv := api.NewServer(store, nil, nil, make([]byte, 32))
+	body, err := json.Marshal(db.Source{
+		Name:         "Docs",
+		URL:          "https://docs.example.com",
+		IncludePaths: []string{"https://docs.example.com/guides/", "https://docs.example.com/reference/"},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	r := httptest.NewRequest(http.MethodPut, "/api/sources/"+itoa(id), bytes.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var updated db.Source
+	if err := json.NewDecoder(w.Body).Decode(&updated); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	want := []string{"https://docs.example.com/guides/", "https://docs.example.com/reference/"}
+	if !reflect.DeepEqual(updated.IncludePaths, want) {
+		t.Fatalf("IncludePaths = %#v, want %#v", updated.IncludePaths, want)
+	}
+	if updated.IncludePath != want[0] {
+		t.Fatalf("IncludePath = %q, want first path", updated.IncludePath)
+	}
+}
+
+func TestCreateSource_IncludePathsRejectsBadURL(t *testing.T) {
+	store := openTestStore(t)
+	srv := api.NewServer(store, nil, nil, make([]byte, 32))
+	body, _ := json.Marshal(db.Source{
+		Name:         "Docs",
+		Type:         "web",
+		URL:          "https://docs.example.com",
+		IncludePaths: []string{"https://docs.example.com/guides/", "://bad-url"},
+	})
+
+	r := httptest.NewRequest(http.MethodPost, "/api/sources", bytes.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+```
+
+Add `reflect` to imports.
+
+- [ ] **Step 4.2: Run API tests and verify failure if validation is missing**
+
+Run:
+
+```bash
+CGO_ENABLED=1 go test -tags sqlite_fts5 ./internal/api -run 'Test(UpdateSource_IncludePaths|CreateSource_IncludePathsRejectsBadURL)'
+```
+
+Expected: one or both tests fail until DB and validation behavior are complete.
+
+- [ ] **Step 4.3: Validate all include path entries**
+
+In `internal/api/handlers.go`, import `sourcepaths` and update `validateSourceURLs`:
+
+```go
+for _, includePath := range sourcepaths.Normalize(src.IncludePath, src.IncludePaths) {
+	if strings.Contains(includePath, "://") {
+		if err := validateHTTPURL(includePath, "include_paths"); err != nil {
+			return err
+		}
+	}
+}
+```
+
+Remove or replace the old single `src.IncludePath` block. Keep the logic URL-shape based because `github_repo` paths are bare subpaths.
+
+- [ ] **Step 4.4: Run API tests**
+
+Run:
+
+```bash
+CGO_ENABLED=1 go test -tags sqlite_fts5 ./internal/api
+```
+
+Expected: pass.
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add internal/api/handlers.go internal/api/handlers_test.go
+git commit -m "feat(api): accept multiple include paths"
+```
+
+## Task 5: Web Adapter Multiple Prefix Matching
+
+**Files:**
+- Modify: `internal/adapter/web/web.go`
+- Modify: `internal/adapter/web/web_test.go`
+
+- [ ] **Step 5.1: Add filter helper tests**
+
+In `internal/adapter/web/web_test.go`, add:
+
+```go
+func TestFilterURL_IncludePathsFiltersCorrectly(t *testing.T) {
+	withLookup(t, map[string][]net.IP{
+		"docs.example.com": {net.ParseIP("1.2.3.4")},
+	})
+	base := mustParseURL("https://docs.example.com/docs/")
+	filterPaths := []string{"/docs/guide/", "/docs/reference/"}
+
+	cases := []struct {
+		rawURL string
+		want   bool
+	}{
+		{"https://docs.example.com/docs/guide/page1", true},
+		{"https://docs.example.com/docs/reference/page2", true},
+		{"https://docs.example.com/docs/api/page3", false},
+	}
+
+	for _, tc := range cases {
+		u := mustParseURL(tc.rawURL)
+		got := filterURLAny(context.Background(), u, base, filterPaths)
+		if got != tc.want {
+			t.Errorf("filterURLAny(%q) = %v, want %v", tc.rawURL, got, tc.want)
+		}
+	}
+}
+```
+
+- [ ] **Step 5.2: Run web adapter test and verify it fails**
+
+Run:
+
+```bash
+CGO_ENABLED=1 go test -tags sqlite_fts5 ./internal/adapter/web -run TestFilterURL_IncludePathsFiltersCorrectly
+```
+
+Expected: fail because `filterURLAny` does not exist.
+
+- [ ] **Step 5.3: Implement web include path parsing**
+
+In `internal/adapter/web/web.go`, import `sourcepaths`.
+
+Replace single `filterPath` setup with:
+
+```go
+filterPaths := []string{strings.TrimRight(base.Path, "/") + "/"}
+includePaths := sourcepaths.Normalize(src.IncludePath, src.IncludePaths)
+if len(includePaths) > 0 {
+	filterPaths = make([]string, 0, len(includePaths))
+	for _, includePath := range includePaths {
+		includeParsed, parseErr := url.Parse(includePath)
+		if parseErr != nil {
+			return 0, nil, fmt.Errorf("web adapter: parse include_path: %w", parseErr)
+		}
+		if !sameOrigin(includeParsed, base) {
+			return 0, nil, fmt.Errorf("web adapter: include_path %q must share origin with source URL %q", includePath, src.URL)
+		}
+		filterPaths = append(filterPaths, strings.TrimRight(includeParsed.Path, "/")+"/")
+	}
+}
+```
+
+In the sitemap loop, replace:
+
+```go
+if !filterURL(ctx, parsed, base, filterPath) {
+```
+
+with:
+
+```go
+if !filterURLAny(ctx, parsed, base, filterPaths) {
+```
+
+Add helper:
+
+```go
+func filterURLAny(ctx context.Context, u, base *url.URL, filterPaths []string) bool {
+	for _, filterPath := range filterPaths {
+		if filterURL(ctx, u, base, filterPath) {
+			return true
+		}
+	}
+	return false
+}
+```
+
+- [ ] **Step 5.4: Run web adapter tests**
+
+Run:
+
+```bash
+CGO_ENABLED=1 go test -tags sqlite_fts5 ./internal/adapter/web
+```
+
+Expected: pass.
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add internal/adapter/web/web.go internal/adapter/web/web_test.go
+git commit -m "feat(web): crawl multiple include path prefixes"
+```
+
+## Task 6: GitHub Repo Adapter Multiple Prefix Matching
+
+**Files:**
+- Modify: `internal/adapter/githubrepo/githubrepo.go`
+- Modify: `internal/adapter/githubrepo/githubrepo_test.go`
+
+- [ ] **Step 6.1: Add multi-subfolder test**
+
+In `internal/adapter/githubrepo/githubrepo_test.go`, add:
+
+```go
+func TestCrawl_IncludePaths_ScopedToMultipleSubfolders(t *testing.T) {
+	tarball := buildTarball(t, "owner-repo-abc123", map[string][]byte{
+		"README.md":             []byte("# Root\n"),
+		"docs/guide.md":         []byte("# Guide\n"),
+		"examples/tutorial.md":  []byte("# Tutorial\n"),
+		"internal/notes.md":     []byte("# Internal\n"),
+	})
+	srv := tarballServer(t, tarball)
+
+	_, ch, err := githubrepo.NewAdapter(srv.URL).Crawl(context.Background(), config.SourceConfig{
+		Type:         "github_repo",
+		Repo:         "owner/repo",
+		Branch:       "main",
+		IncludePaths: []string{"docs/", "examples/"},
+	}, 42)
+	if err != nil {
+		t.Fatalf("Crawl: %v", err)
+	}
+	pages := drainPages(context.Background(), t, ch)
+	if len(pages) != 2 {
+		t.Fatalf("got %d pages, want 2; URLs %v", len(pages), urls(pages))
+	}
+}
+
+func TestCrawl_IncludePaths_RejectsTraversal(t *testing.T) {
+	a := githubrepo.NewAdapter("https://api.github.test")
+	_, _, err := a.Crawl(context.Background(), config.SourceConfig{
+		Type:         "github_repo",
+		Repo:         "owner/repo",
+		IncludePaths: []string{"docs/", "../secrets"},
+	}, 1)
+	if err == nil {
+		t.Fatal("expected error for traversal include_paths, got nil")
+	}
+	if !strings.Contains(err.Error(), "include_path") {
+		t.Errorf("error should mention include_path: %v", err)
+	}
+}
+```
+
+- [ ] **Step 6.2: Run GitHub repo adapter tests and verify failure**
+
+Run:
+
+```bash
+CGO_ENABLED=1 go test -tags sqlite_fts5 ./internal/adapter/githubrepo -run 'TestCrawl_IncludePaths'
+```
+
+Expected: fail until adapter consumes `IncludePaths`.
+
+- [ ] **Step 6.3: Implement multiple repo prefixes**
+
+In `internal/adapter/githubrepo/githubrepo.go`, import `sourcepaths`.
+
+At the top of `Crawl`, replace single `includePath` logic with:
+
+```go
+includePaths := normalizeIncludePaths(sourcepaths.Normalize(src.IncludePath, src.IncludePaths))
+for _, includePath := range sourcepaths.Normalize(src.IncludePath, src.IncludePaths) {
+	if err := validateIncludePath(includePath); err != nil {
+		return 0, nil, err
+	}
+}
+```
+
+Add helpers:
+
+```go
+func normalizeIncludePaths(paths []string) []string {
+	out := make([]string, 0, len(paths))
+	for _, p := range paths {
+		out = append(out, normalizeIncludePath(p))
+	}
+	return out
+}
+
+func hasIncludePathPrefix(relPath string, includePaths []string) bool {
+	if len(includePaths) == 0 {
+		return true
+	}
+	for _, includePath := range includePaths {
+		if strings.HasPrefix(relPath, includePath) {
+			return true
+		}
+	}
+	return false
+}
+
+func trimFirstIncludePathPrefix(relPath string, includePaths []string) string {
+	for _, includePath := range includePaths {
+		if strings.HasPrefix(relPath, includePath) {
+			return strings.TrimPrefix(relPath, includePath)
+		}
+	}
+	return relPath
+}
+```
+
+Replace filtering:
+
+```go
+if includePath != "" && !strings.HasPrefix(relPath, includePath) {
+	continue
+}
+```
+
+with:
+
+```go
+if !hasIncludePathPrefix(relPath, includePaths) {
+	continue
+}
+```
+
+Change `buildPage` signature to:
+
+```go
+func buildPage(repo, branch string, includePaths []string, relPath, content string, sourceID int64) db.Page {
+	rel := trimFirstIncludePathPrefix(relPath, includePaths)
+```
+
+Update call sites accordingly.
+
+- [ ] **Step 6.4: Run GitHub repo adapter tests**
+
+Run:
+
+```bash
+CGO_ENABLED=1 go test -tags sqlite_fts5 ./internal/adapter/githubrepo
+```
+
+Expected: pass.
+
+- [ ] **Step 6.5: Commit**
+
+```bash
+git add internal/adapter/githubrepo/githubrepo.go internal/adapter/githubrepo/githubrepo_test.go
+git commit -m "feat(github_repo): index multiple include paths"
+```
+
+## Task 7: Web UI Multi-Path Control
+
+**Files:**
+- Modify: `web/static/app.js`
+- Modify: `web/static/index.html`
+- Modify: `web/static/style.css`
+
+- [ ] **Step 7.1: Update Alpine source state helpers**
+
+In `web/static/app.js`, update `blankSource`:
+
+```js
+function blankSource(type = 'web') {
+  return { Name: '', Type: type, URL: '', Repo: '', Branch: '', IncludePath: '', IncludePaths: [], CrawlSchedule: '' }
+}
+```
+
+Add helper functions before `app()`:
+
+```js
+function sourceIncludePaths(src) {
+  const paths = Array.isArray(src.IncludePaths) ? src.IncludePaths : []
+  const combined = [src.IncludePath || '', ...paths]
+  return [...new Set(combined.map(p => (p || '').trim()).filter(Boolean))]
+}
+
+function prepareSourcePayload(src) {
+  const paths = sourceIncludePaths(src)
+  return { ...src, IncludePaths: paths, IncludePath: paths[0] || '' }
+}
+```
+
+- [ ] **Step 7.2: Use normalized payloads**
+
+In `addSource`, replace:
+
+```js
+const body = { ...this.newSource }
+```
+
+with:
+
+```js
+const body = prepareSourcePayload(this.newSource)
+```
+
+In `updateSource`, replace:
+
+```js
+const body = { ...this.editSource }
+```
+
+with:
+
+```js
+const body = prepareSourcePayload(this.editSource)
+```
+
+In `startEditSource`, set:
+
+```js
+IncludePath: src.IncludePath || '',
+IncludePaths: sourceIncludePaths(src),
+```
+
+- [ ] **Step 7.3: Add Alpine methods for rows and labels**
+
+Inside `app()` methods, add:
+
+```js
+includePathPlaceholder(type) {
+  return type === 'github_repo' ? 'docs/' : 'https://docs.example.com/guides/'
+},
+
+includePathHelp(type) {
+  if (type === 'github_repo') return 'Only files under these repository folders will be indexed. Leave empty to index the whole repo.'
+  return 'Only same-site URLs under these prefixes will be indexed. Leave empty to use the source URL path.'
+},
+
+ensureIncludePathRow(src) {
+  if (!Array.isArray(src.IncludePaths)) src.IncludePaths = []
+  if (src.IncludePaths.length === 0) src.IncludePaths.push('')
+},
+
+addIncludePathRow(src) {
+  if (!Array.isArray(src.IncludePaths)) src.IncludePaths = []
+  src.IncludePaths.push('')
+},
+
+removeIncludePathRow(src, index) {
+  if (!Array.isArray(src.IncludePaths)) src.IncludePaths = []
+  src.IncludePaths.splice(index, 1)
+},
+
+sourceDisplayPaths(src) {
+  return sourceIncludePaths(src).join(', ')
+},
+```
+
+- [ ] **Step 7.4: Update source display URL for GitHub repo**
+
+In `sourceDisplayURL`, keep showing the repo tree base without appending one include path:
+
+```js
+if (src.Type === 'github_repo' && src.Repo) {
+  const branch = src.Branch || 'main'
+  return `https://github.com/${src.Repo}/tree/${branch}`
+}
+```
+
+- [ ] **Step 7.5: Replace add-form include path inputs**
+
+In `web/static/index.html`, replace the separate single `IncludePath` templates for `web` and `github_repo` with a shared block shown for both:
+
+```html
+<template x-if="newSource.Type === 'web' || newSource.Type === 'github_repo'">
+  <div class="path-scope" x-init="ensureIncludePathRow(newSource)">
+    <label>Crawl only these paths</label>
+    <p class="muted" x-text="includePathHelp(newSource.Type)"></p>
+    <template x-for="(_, index) in newSource.IncludePaths" :key="index">
+      <div class="path-row">
+        <input :type="newSource.Type === 'web' ? 'url' : 'text'"
+               x-model="newSource.IncludePaths[index]"
+               :placeholder="includePathPlaceholder(newSource.Type)" />
+        <button type="button" class="secondary" @click="removeIncludePathRow(newSource, index)">Remove</button>
+      </div>
+    </template>
+    <button type="button" class="secondary" @click="addIncludePathRow(newSource)">Add path</button>
+  </div>
+</template>
+```
+
+- [ ] **Step 7.6: Replace edit-form include path inputs**
+
+Use the same block with `editSource`:
+
+```html
+<template x-if="editSource.Type === 'web' || editSource.Type === 'github_repo'">
+  <div class="path-scope">
+    <label>Crawl only these paths</label>
+    <p class="muted" x-text="includePathHelp(editSource.Type)"></p>
+    <template x-for="(_, index) in editSource.IncludePaths" :key="index">
+      <div class="path-row">
+        <input :type="editSource.Type === 'web' ? 'url' : 'text'"
+               x-model="editSource.IncludePaths[index]"
+               :placeholder="includePathPlaceholder(editSource.Type)" />
+        <button type="button" class="secondary" @click="removeIncludePathRow(editSource, index)">Remove</button>
+      </div>
+    </template>
+    <button type="button" class="secondary" @click="addIncludePathRow(editSource)">Add path</button>
+  </div>
+</template>
+```
+
+- [ ] **Step 7.7: Display scoped paths in source metadata**
+
+Under source metadata display, add:
+
+```html
+<div class="muted" x-show="sourceDisplayPaths(src)" x-text="'Crawls only: ' + sourceDisplayPaths(src)"></div>
+```
+
+- [ ] **Step 7.8: Add minimal styles**
+
+In `web/static/style.css`, add:
+
+```css
+.path-scope {
+  margin-bottom: 1rem;
+}
+
+.path-scope label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.35rem;
+}
+
+.path-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.path-row input {
+  flex: 1;
+}
+```
+
+- [ ] **Step 7.9: Run static sanity checks**
+
+Run:
+
+```bash
+rg -n "IncludePath|IncludePaths|Crawl only these paths|includePathHelp" web/static
+```
+
+Expected: no old single input remains for web/github_repo, and new helper text is present.
+
+- [ ] **Step 7.10: Commit**
+
+```bash
+git add web/static/app.js web/static/index.html web/static/style.css
+git commit -m "feat(ui): edit multiple include path filters"
+```
+
+## Task 8: Documentation And Examples
+
+**Files:**
+- Modify: `docs/configuration.md`
+- Modify: `docs/sources.md`
+- Modify: `config.example.yaml`
+
+- [ ] **Step 8.1: Update config reference**
+
+In `docs/configuration.md`, replace the `sources[].include_path` row with:
+
+```markdown
+| `sources[].include_path` | Legacy single path filter. Prefer `include_paths` for new config. |
+| `sources[].include_paths` | For `web`: only same-origin URLs under these prefixes are indexed. For `github_repo`: only files under these repository folders are indexed. Empty means the current whole-source behavior. |
+```
+
+- [ ] **Step 8.2: Update source examples**
+
+In `docs/sources.md`, update the web and GitHub repo examples to use `include_paths` with two entries. Add one sentence near each example:
+
+```markdown
+`include_paths` is a filter: only matching pages are indexed. It does not add extra crawl roots.
+```
+
+For GitHub repo:
+
+```markdown
+`include_paths` is a filter: only matching files are indexed. It does not add extra repositories or branches.
+```
+
+- [ ] **Step 8.3: Update example config**
+
+In `config.example.yaml`, update commented examples:
+
+```yaml
+  #   include_paths:
+  #     - https://argo-cd.readthedocs.io/en/stable/operator-manual/
+  #     - https://argo-cd.readthedocs.io/en/stable/user-guide/
+```
+
+and:
+
+```yaml
+  #   include_paths:
+  #     - docs/
+  #     - examples/
+```
+
+- [ ] **Step 8.4: Run docs grep**
+
+Run:
+
+```bash
+rg -n "include_path|include_paths|Crawl only" docs config.example.yaml
+```
+
+Expected: docs mention `include_paths` as preferred and `include_path` as legacy compatibility.
+
+- [ ] **Step 8.5: Commit**
+
+```bash
+git add docs/configuration.md docs/sources.md config.example.yaml
+git commit -m "docs: document multiple include path filters"
+```
+
+## Task 9: Final Verification
+
+**Files:**
+- All modified files
+
+- [ ] **Step 9.1: Format Go files**
+
+Run:
+
+```bash
+gofmt -w internal/config internal/sourcepaths internal/db internal/crawler internal/api internal/mcp internal/adapter/web internal/adapter/githubrepo
+```
+
+Expected: no output.
+
+- [ ] **Step 9.2: Run vet**
+
+Run:
+
+```bash
+CGO_ENABLED=1 go vet -tags sqlite_fts5 ./...
+```
+
+Expected: pass.
+
+- [ ] **Step 9.3: Run race tests**
+
+Run:
+
+```bash
+CGO_ENABLED=1 go test -tags sqlite_fts5 -race ./...
+```
+
+Expected: pass.
+
+- [ ] **Step 9.4: Optional local UI check**
+
+Run:
+
+```bash
+make build
+```
+
+Then start the app using the repo's normal local command and verify:
+
+- Add Source for `web` shows **Crawl only these paths** and same-site helper text.
+- Add Source for `github_repo` shows repository-folder helper text.
+- Adding/removing rows works.
+- Edit Source initializes existing `IncludePaths`, or falls back from legacy `IncludePath`.
+- The submitted payload contains `IncludePaths` and first-path `IncludePath`.
+
+- [ ] **Step 9.5: Final commit if formatting changed files**
+
+If Step 9.1 changed any files after earlier commits:
+
+```bash
+git add .
+git commit -m "chore: format multiple include paths changes"
+```
+
+## Self-Review Checklist
+
+- Design coverage: config, DB, crawler, API, MCP, web adapter, GitHub repo adapter, UI, docs, and tests are all represented.
+- Compatibility: `include_path` remains accepted, stored, and returned.
+- UI wording: the plan uses "Crawl only these paths" and explicit filter helper text.
+- Scope: GitHub Wiki and Azure DevOps are intentionally unchanged.
+- Verification: final `gofmt`, `go vet`, and race tests are included with the required `CGO_ENABLED=1` and `sqlite_fts5` tag.

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -10,9 +10,13 @@ Crawls public websites. Discovers pages via sitemap, falls back to link followin
 - name: ArgoCD Operator Manual
   type: web
   url: https://argo-cd.readthedocs.io/en/stable/
-  include_path: https://argo-cd.readthedocs.io/en/stable/operator-manual/
+  include_paths:
+    - https://argo-cd.readthedocs.io/en/stable/operator-manual/
+    - https://argo-cd.readthedocs.io/en/stable/user-guide/
   crawl_schedule: "@weekly"
 ```
+
+`include_paths` is a filter: only matching pages are indexed. It does not add extra crawl roots.
 
 ## GitHub Wiki (`type: github_wiki`)
 
@@ -27,16 +31,20 @@ Indexes a GitHub repository's wiki. Public wikis work without authentication. Fo
 
 ## GitHub Repo (`type: github_repo`)
 
-Indexes Markdown (`.md`, `.mdx`) and text (`.txt`) files directly from a repository's tree via the GitHub tarball endpoint. Files larger than 5 MiB are skipped. Use `include_path` to restrict indexing to a subfolder such as `docs/`.
+Indexes Markdown (`.md`, `.mdx`) and text (`.txt`) files directly from a repository's tree via the GitHub tarball endpoint. Files larger than 5 MiB are skipped. Use `include_paths` to restrict indexing to repository folders such as `docs/` and `help/tests/`.
 
 ```yaml
 - name: My Project Docs
   type: github_repo
   repo: owner/repo
   branch: main
-  include_path: docs/
+  include_paths:
+    - docs/
+    - help/tests/
   crawl_schedule: "@daily"
 ```
+
+`include_paths` is a filter: only matching files are indexed. It does not add extra repositories or branches.
 
 Public repos work without authentication. For private repos, click **Connect** in the Web UI and paste a [fine-grained PAT](https://github.com/settings/personal-access-tokens/new) with **Contents: Read-only** on the target repo.
 

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -11,12 +11,12 @@ Crawls public websites. Discovers pages via sitemap, falls back to link followin
   type: web
   url: https://argo-cd.readthedocs.io/en/stable/
   include_paths:
-    - https://argo-cd.readthedocs.io/en/stable/operator-manual/
-    - https://argo-cd.readthedocs.io/en/stable/user-guide/
+    - operator-manual/
+    - user-guide/
   crawl_schedule: "@weekly"
 ```
 
-`include_paths` is a filter: only matching pages are indexed. It does not add extra crawl roots.
+`include_paths` is a filter: only matching pages are indexed. It does not add extra crawl roots. For web sources, entries can be relative to `url` (`operator-manual/`), root-relative (`/en/stable/operator-manual/`), or full same-origin URLs.
 
 ## GitHub Wiki (`type: github_wiki`)
 

--- a/internal/adapter/githubrepo/githubrepo.go
+++ b/internal/adapter/githubrepo/githubrepo.go
@@ -18,6 +18,7 @@ import (
 	"github.com/mathwro/DocuMcp/internal/config"
 	"github.com/mathwro/DocuMcp/internal/db"
 	"github.com/mathwro/DocuMcp/internal/httpsafe"
+	"github.com/mathwro/DocuMcp/internal/sourcepaths"
 )
 
 // tarballClient is used for all tarball fetches; its CheckRedirect hook
@@ -49,11 +50,13 @@ func (a *Adapter) Crawl(ctx context.Context, src config.SourceConfig, sourceID i
 	if branch == "" {
 		branch = "main"
 	}
-	includePath := normalizeIncludePath(src.IncludePath)
-
-	if err := validateIncludePath(src.IncludePath); err != nil {
-		return 0, nil, err
+	rawIncludePaths := sourcepaths.Normalize(src.IncludePath, src.IncludePaths)
+	for _, includePath := range rawIncludePaths {
+		if err := validateIncludePath(includePath); err != nil {
+			return 0, nil, err
+		}
 	}
+	includePaths := normalizeIncludePaths(rawIncludePaths)
 
 	resp, err := a.fetchTarball(ctx, src, branch)
 	if err != nil {
@@ -109,7 +112,7 @@ func (a *Adapter) Crawl(ctx context.Context, src config.SourceConfig, sourceID i
 			if !ok {
 				continue
 			}
-			if includePath != "" && !strings.HasPrefix(relPath, includePath) {
+			if !hasIncludePathPrefix(relPath, includePaths) {
 				continue
 			}
 			if _, allowed := allowedExts[strings.ToLower(path.Ext(relPath))]; !allowed {
@@ -126,7 +129,7 @@ func (a *Adapter) Crawl(ctx context.Context, src config.SourceConfig, sourceID i
 				continue
 			}
 
-			page := buildPage(src.Repo, branch, includePath, relPath, string(content), sourceID)
+			page := buildPage(src.Repo, branch, includePaths, relPath, string(content), sourceID)
 			select {
 			case <-ctx.Done():
 				return
@@ -217,9 +220,38 @@ func normalizeIncludePath(p string) string {
 	return p
 }
 
+func normalizeIncludePaths(paths []string) []string {
+	out := make([]string, 0, len(paths))
+	for _, p := range paths {
+		out = append(out, normalizeIncludePath(p))
+	}
+	return out
+}
+
+func hasIncludePathPrefix(relPath string, includePaths []string) bool {
+	if len(includePaths) == 0 {
+		return true
+	}
+	for _, includePath := range includePaths {
+		if strings.HasPrefix(relPath, includePath) {
+			return true
+		}
+	}
+	return false
+}
+
+func trimFirstIncludePathPrefix(relPath string, includePaths []string) string {
+	for _, includePath := range includePaths {
+		if strings.HasPrefix(relPath, includePath) {
+			return strings.TrimPrefix(relPath, includePath)
+		}
+	}
+	return relPath
+}
+
 // buildPage constructs a db.Page for a matched file.
-func buildPage(repo, branch, includePath, relPath, content string, sourceID int64) db.Page {
-	rel := strings.TrimPrefix(relPath, includePath)
+func buildPage(repo, branch string, includePaths []string, relPath, content string, sourceID int64) db.Page {
+	rel := trimFirstIncludePathPrefix(relPath, includePaths)
 	stem := strings.TrimSuffix(rel, path.Ext(rel))
 	segments := strings.Split(stem, "/")
 	// filter empty segments (defensive; shouldn't occur after TrimPrefix)

--- a/internal/adapter/githubrepo/githubrepo_test.go
+++ b/internal/adapter/githubrepo/githubrepo_test.go
@@ -175,12 +175,12 @@ func TestCrawl_IncludePath_ScopedToSubfolder(t *testing.T) {
 
 func TestCrawl_IncludePaths_ScopedToMultipleSubfolders(t *testing.T) {
 	tarball := buildTarball(t, "owner-repo-abc123", map[string][]byte{
-		"README.md":              []byte("# Root\n"),
-		"docs/guide.md":          []byte("# Guide\n"),
-		"help/tests/writing.md":  []byte("# Writing Tests\n"),
-		"help/tests/running.md":  []byte("# Running Tests\n"),
-		"help/release/notes.md":  []byte("# Release Notes\n"),
-		"internal/notes.md":      []byte("# Internal\n"),
+		"README.md":             []byte("# Root\n"),
+		"docs/guide.md":         []byte("# Guide\n"),
+		"help/tests/writing.md": []byte("# Writing Tests\n"),
+		"help/tests/running.md": []byte("# Running Tests\n"),
+		"help/release/notes.md": []byte("# Release Notes\n"),
+		"internal/notes.md":     []byte("# Internal\n"),
 	})
 	srv := tarballServer(t, tarball)
 	includePaths := []string{"docs/", "help/tests/"}

--- a/internal/adapter/githubrepo/githubrepo_test.go
+++ b/internal/adapter/githubrepo/githubrepo_test.go
@@ -173,6 +173,47 @@ func TestCrawl_IncludePath_ScopedToSubfolder(t *testing.T) {
 	}
 }
 
+func TestCrawl_IncludePaths_ScopedToMultipleSubfolders(t *testing.T) {
+	tarball := buildTarball(t, "owner-repo-abc123", map[string][]byte{
+		"README.md":                   []byte("# Root\n"),
+		"docs/guide.md":               []byte("# Guide\n"),
+		"examples/tutorial.md":        []byte("# Tutorial\n"),
+		"packages/pkg/docs/readme.md": []byte("# Package Docs\n"),
+		"internal/notes.md":           []byte("# Internal\n"),
+	})
+	srv := tarballServer(t, tarball)
+	includePaths := []string{"docs/", "examples/", "packages/pkg/docs/"}
+
+	_, ch, err := githubrepo.NewAdapter(srv.URL).Crawl(context.Background(), config.SourceConfig{
+		Type:         "github_repo",
+		Repo:         "owner/repo",
+		Branch:       "main",
+		IncludePaths: includePaths,
+	}, 42)
+	if err != nil {
+		t.Fatalf("Crawl: %v", err)
+	}
+	pages := drainPages(context.Background(), t, ch)
+	if len(pages) != len(includePaths) {
+		t.Fatalf("got %d pages, want one page per configured prefix; URLs %v", len(pages), urls(pages))
+	}
+}
+
+func TestCrawl_IncludePaths_RejectsTraversal(t *testing.T) {
+	a := githubrepo.NewAdapter("https://api.github.test")
+	_, _, err := a.Crawl(context.Background(), config.SourceConfig{
+		Type:         "github_repo",
+		Repo:         "owner/repo",
+		IncludePaths: []string{"docs/", "../secrets"},
+	}, 1)
+	if err == nil {
+		t.Fatal("expected error for traversal include_paths, got nil")
+	}
+	if !strings.Contains(err.Error(), "include_path") {
+		t.Errorf("error should mention include_path: %v", err)
+	}
+}
+
 func equalStrings(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/internal/adapter/githubrepo/githubrepo_test.go
+++ b/internal/adapter/githubrepo/githubrepo_test.go
@@ -175,14 +175,15 @@ func TestCrawl_IncludePath_ScopedToSubfolder(t *testing.T) {
 
 func TestCrawl_IncludePaths_ScopedToMultipleSubfolders(t *testing.T) {
 	tarball := buildTarball(t, "owner-repo-abc123", map[string][]byte{
-		"README.md":                   []byte("# Root\n"),
-		"docs/guide.md":               []byte("# Guide\n"),
-		"examples/tutorial.md":        []byte("# Tutorial\n"),
-		"packages/pkg/docs/readme.md": []byte("# Package Docs\n"),
-		"internal/notes.md":           []byte("# Internal\n"),
+		"README.md":              []byte("# Root\n"),
+		"docs/guide.md":          []byte("# Guide\n"),
+		"help/tests/writing.md":  []byte("# Writing Tests\n"),
+		"help/tests/running.md":  []byte("# Running Tests\n"),
+		"help/release/notes.md":  []byte("# Release Notes\n"),
+		"internal/notes.md":      []byte("# Internal\n"),
 	})
 	srv := tarballServer(t, tarball)
-	includePaths := []string{"docs/", "examples/", "packages/pkg/docs/"}
+	includePaths := []string{"docs/", "help/tests/"}
 
 	_, ch, err := githubrepo.NewAdapter(srv.URL).Crawl(context.Background(), config.SourceConfig{
 		Type:         "github_repo",
@@ -194,8 +195,8 @@ func TestCrawl_IncludePaths_ScopedToMultipleSubfolders(t *testing.T) {
 		t.Fatalf("Crawl: %v", err)
 	}
 	pages := drainPages(context.Background(), t, ch)
-	if len(pages) != len(includePaths) {
-		t.Fatalf("got %d pages, want one page per configured prefix; URLs %v", len(pages), urls(pages))
+	if len(pages) != 3 {
+		t.Fatalf("got %d pages, want docs/ plus help/tests/ files; URLs %v", len(pages), urls(pages))
 	}
 }
 

--- a/internal/adapter/web/web.go
+++ b/internal/adapter/web/web.go
@@ -56,16 +56,9 @@ func (a *WebAdapter) Crawl(ctx context.Context, src config.SourceConfig, sourceI
 	filterPaths := []string{strings.TrimRight(base.Path, "/") + "/"}
 	includePaths := sourcepaths.Normalize(src.IncludePath, src.IncludePaths)
 	if len(includePaths) > 0 {
-		filterPaths = make([]string, 0, len(includePaths))
-		for _, includePath := range includePaths {
-			includeParsed, parseErr := url.Parse(includePath)
-			if parseErr != nil {
-				return 0, nil, fmt.Errorf("web adapter: parse include_path: %w", parseErr)
-			}
-			if !sameOrigin(includeParsed, base) {
-				return 0, nil, fmt.Errorf("web adapter: include_path %q must share origin with source URL %q", includePath, src.URL)
-			}
-			filterPaths = append(filterPaths, strings.TrimRight(includeParsed.Path, "/")+"/")
+		filterPaths, err = webIncludePathFilterPaths(base, includePaths)
+		if err != nil {
+			return 0, nil, err
 		}
 	}
 
@@ -263,6 +256,27 @@ func filterURLAny(ctx context.Context, u *url.URL, base *url.URL, filterPaths []
 		}
 	}
 	return false
+}
+
+func webIncludePathFilterPaths(base *url.URL, includePaths []string) ([]string, error) {
+	filterPaths := make([]string, 0, len(includePaths))
+	for _, includePath := range includePaths {
+		includeParsed, parseErr := url.Parse(includePath)
+		if parseErr != nil {
+			return nil, fmt.Errorf("web adapter: parse include_path: %w", parseErr)
+		}
+		if includeParsed.IsAbs() {
+			if !sameOrigin(includeParsed, base) {
+				return nil, fmt.Errorf("web adapter: include_path %q must share origin with source URL %q", includePath, base.String())
+			}
+		} else if includeParsed.Host != "" {
+			return nil, fmt.Errorf("web adapter: include_path %q must be a relative path or share origin with source URL %q", includePath, base.String())
+		} else {
+			includeParsed = base.ResolveReference(includeParsed)
+		}
+		filterPaths = append(filterPaths, strings.TrimRight(includeParsed.Path, "/")+"/")
+	}
+	return filterPaths, nil
 }
 
 // isAllowedHost delegates to httpsafe.AllowedHost.

--- a/internal/adapter/web/web.go
+++ b/internal/adapter/web/web.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mathwro/DocuMcp/internal/config"
 	"github.com/mathwro/DocuMcp/internal/db"
 	"github.com/mathwro/DocuMcp/internal/httpsafe"
+	"github.com/mathwro/DocuMcp/internal/sourcepaths"
 )
 
 func init() {
@@ -52,16 +53,20 @@ func (a *WebAdapter) Crawl(ctx context.Context, src config.SourceConfig, sourceI
 	// Determine the path prefix to use for URL filtering.
 	// If include_path is set, validate it shares the same origin and use its path.
 	// Otherwise fall back to the source URL's own path.
-	filterPath := strings.TrimRight(base.Path, "/") + "/"
-	if src.IncludePath != "" {
-		includeParsed, parseErr := url.Parse(src.IncludePath)
-		if parseErr != nil {
-			return 0, nil, fmt.Errorf("web adapter: parse include_path: %w", parseErr)
+	filterPaths := []string{strings.TrimRight(base.Path, "/") + "/"}
+	includePaths := sourcepaths.Normalize(src.IncludePath, src.IncludePaths)
+	if len(includePaths) > 0 {
+		filterPaths = make([]string, 0, len(includePaths))
+		for _, includePath := range includePaths {
+			includeParsed, parseErr := url.Parse(includePath)
+			if parseErr != nil {
+				return 0, nil, fmt.Errorf("web adapter: parse include_path: %w", parseErr)
+			}
+			if !sameOrigin(includeParsed, base) {
+				return 0, nil, fmt.Errorf("web adapter: include_path %q must share origin with source URL %q", includePath, src.URL)
+			}
+			filterPaths = append(filterPaths, strings.TrimRight(includeParsed.Path, "/")+"/")
 		}
-		if !sameOrigin(includeParsed, base) {
-			return 0, nil, fmt.Errorf("web adapter: include_path %q must share origin with source URL %q", src.IncludePath, src.URL)
-		}
-		filterPath = strings.TrimRight(includeParsed.Path, "/") + "/"
 	}
 
 	// Discover and filter URLs before starting the goroutine so we can return
@@ -77,7 +82,7 @@ func (a *WebAdapter) Crawl(ctx context.Context, src config.SourceConfig, sourceI
 			slog.Warn("web: skipping cross-origin sitemap URL", "url", u, "base", src.URL)
 			continue
 		}
-		if !filterURL(ctx, parsed, base, filterPath) {
+		if !filterURLAny(ctx, parsed, base, filterPaths) {
 			if !isAllowedHost(ctx, parsed) {
 				slog.Warn("web: skipping blocked host in sitemap URL", "url", u)
 			}
@@ -249,6 +254,15 @@ func filterURL(ctx context.Context, u *url.URL, base *url.URL, filterPath string
 		return false
 	}
 	return true
+}
+
+func filterURLAny(ctx context.Context, u *url.URL, base *url.URL, filterPaths []string) bool {
+	for _, filterPath := range filterPaths {
+		if filterURL(ctx, u, base, filterPath) {
+			return true
+		}
+	}
+	return false
 }
 
 // isAllowedHost delegates to httpsafe.AllowedHost.

--- a/internal/adapter/web/web_test.go
+++ b/internal/adapter/web/web_test.go
@@ -49,6 +49,23 @@ func TestCrawl_IncludePath_CrossOrigin(t *testing.T) {
 	}
 }
 
+func TestWebIncludePathFilterPaths_ResolvesRelativePaths(t *testing.T) {
+	base := mustParseURL("https://docs.example.com/docs/")
+	got, err := webIncludePathFilterPaths(base, []string{"guides/", "/reference/"})
+	if err != nil {
+		t.Fatalf("webIncludePathFilterPaths: %v", err)
+	}
+	want := []string{"/docs/guides/", "/reference/"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+}
+
 func TestFilterURL_IncludePathFiltersCorrectly(t *testing.T) {
 	withLookup(t, map[string][]net.IP{
 		"docs.example.com": {net.ParseIP("1.2.3.4")},

--- a/internal/adapter/web/web_test.go
+++ b/internal/adapter/web/web_test.go
@@ -78,6 +78,31 @@ func TestFilterURL_IncludePathFiltersCorrectly(t *testing.T) {
 	}
 }
 
+func TestFilterURL_IncludePathsFiltersCorrectly(t *testing.T) {
+	withLookup(t, map[string][]net.IP{
+		"docs.example.com": {net.ParseIP("1.2.3.4")},
+	})
+	base := mustParseURL("https://docs.example.com/docs/")
+	filterPaths := []string{"/docs/guide/", "/docs/reference/"}
+
+	cases := []struct {
+		rawURL string
+		want   bool
+	}{
+		{"https://docs.example.com/docs/guide/page1", true},
+		{"https://docs.example.com/docs/reference/page2", true},
+		{"https://docs.example.com/docs/api/page3", false},
+	}
+
+	for _, tc := range cases {
+		u := mustParseURL(tc.rawURL)
+		got := filterURLAny(context.Background(), u, base, filterPaths)
+		if got != tc.want {
+			t.Errorf("filterURLAny(%q) = %v, want %v", tc.rawURL, got, tc.want)
+		}
+	}
+}
+
 func mustParseURL(raw string) *url.URL {
 	u, err := url.Parse(raw)
 	if err != nil {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mathwro/DocuMcp/internal/auth"
 	"github.com/mathwro/DocuMcp/internal/db"
 	"github.com/mathwro/DocuMcp/internal/search"
+	"github.com/mathwro/DocuMcp/internal/sourcepaths"
 )
 
 // writeJSON writes v as JSON to w with the given status code.
@@ -69,11 +70,13 @@ func validateSourceURLs(src db.Source) error {
 			return err
 		}
 	}
-	if src.IncludePath != "" && strings.Contains(src.IncludePath, "://") {
-		// IncludePath is a URL for web sources; for github_repo it's a bare subpath.
-		// If it looks like a URL, validate the scheme.
-		if err := validateHTTPURL(src.IncludePath, "include_path"); err != nil {
-			return err
+	for _, includePath := range sourcepaths.Normalize(src.IncludePath, src.IncludePaths) {
+		if strings.Contains(includePath, "://") {
+			// Include paths are URLs for web sources; for github_repo they're bare subpaths.
+			// If a value looks like a URL, validate the scheme.
+			if err := validateHTTPURL(includePath, "include_paths"); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strconv"
 	"testing"
 
@@ -279,6 +280,67 @@ func TestUpdateSource(t *testing.T) {
 	}
 	if updated.LastCrawled == nil {
 		t.Errorf("expected last crawled to remain set")
+	}
+}
+
+func TestUpdateSource_IncludePaths(t *testing.T) {
+	store := openTestStore(t)
+	id, err := store.InsertSource(db.Source{
+		Name: "Docs",
+		Type: "web",
+		URL:  "https://docs.example.com",
+	})
+	if err != nil {
+		t.Fatalf("InsertSource: %v", err)
+	}
+
+	srv := api.NewServer(store, nil, nil, make([]byte, 32))
+	body, err := json.Marshal(db.Source{
+		Name:         "Docs",
+		URL:          "https://docs.example.com",
+		IncludePaths: []string{"https://docs.example.com/guides/", "https://docs.example.com/reference/"},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	r := httptest.NewRequest(http.MethodPut, "/api/sources/"+itoa(id), bytes.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var updated db.Source
+	if err := json.NewDecoder(w.Body).Decode(&updated); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	want := []string{"https://docs.example.com/guides/", "https://docs.example.com/reference/"}
+	if !reflect.DeepEqual(updated.IncludePaths, want) {
+		t.Fatalf("IncludePaths = %#v, want %#v", updated.IncludePaths, want)
+	}
+	if updated.IncludePath != want[0] {
+		t.Fatalf("IncludePath = %q, want first path", updated.IncludePath)
+	}
+}
+
+func TestCreateSource_IncludePathsRejectsBadURL(t *testing.T) {
+	store := openTestStore(t)
+	srv := api.NewServer(store, nil, nil, make([]byte, 32))
+	body, _ := json.Marshal(db.Source{
+		Name:         "Docs",
+		Type:         "web",
+		URL:          "https://docs.example.com",
+		IncludePaths: []string{"https://docs.example.com/guides/", "://bad-url"},
+	})
+
+	r := httptest.NewRequest(http.MethodPost, "/api/sources", bytes.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,9 +26,10 @@ type SourceConfig struct {
 	Repo   string `yaml:"repo,omitempty"`
 	Branch string `yaml:"branch,omitempty"`
 	// web
-	URL         string `yaml:"url,omitempty"`
-	IncludePath string `yaml:"include_path,omitempty"`
-	Auth        string `yaml:"auth,omitempty"`
+	URL          string   `yaml:"url,omitempty"`
+	IncludePath  string   `yaml:"include_path,omitempty"`
+	IncludePaths []string `yaml:"include_paths,omitempty"`
+	Auth         string   `yaml:"auth,omitempty"`
 	// confluence
 	BaseURL  string `yaml:"base_url,omitempty"`
 	SpaceKey string `yaml:"space_key,omitempty"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config_test
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/mathwro/DocuMcp/internal/config"
@@ -101,5 +102,34 @@ func TestLoadOrDefault_ParseError(t *testing.T) {
 	_, err := config.LoadOrDefault(path)
 	if err == nil {
 		t.Fatal("expected parse error, got nil")
+	}
+}
+
+func TestLoadConfig_IncludePaths(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "include-paths.yaml")
+	data := []byte(`sources:
+  - name: Docs
+    type: web
+    url: https://docs.example.com/
+    include_path: https://docs.example.com/legacy/
+    include_paths:
+      - https://docs.example.com/guides/
+      - https://docs.example.com/reference/
+`)
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("write temp config: %v", err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	src := cfg.Sources[0]
+	if src.IncludePath != "https://docs.example.com/legacy/" {
+		t.Fatalf("IncludePath = %q", src.IncludePath)
+	}
+	want := []string{"https://docs.example.com/guides/", "https://docs.example.com/reference/"}
+	if !reflect.DeepEqual(src.IncludePaths, want) {
+		t.Fatalf("IncludePaths = %#v, want %#v", src.IncludePaths, want)
 	}
 }

--- a/internal/crawler/config_sources.go
+++ b/internal/crawler/config_sources.go
@@ -1,0 +1,35 @@
+package crawler
+
+import (
+	"fmt"
+
+	"github.com/mathwro/DocuMcp/internal/config"
+	"github.com/mathwro/DocuMcp/internal/db"
+)
+
+// SyncConfigSources persists sources declared in config.yaml so they are
+// visible to the Web UI and MCP/API source listings.
+func SyncConfigSources(store *db.Store, cfg *config.Config) error {
+	for _, src := range cfg.Sources {
+		if _, err := store.UpsertSourceConfigByName(configSourceToDB(src)); err != nil {
+			return fmt.Errorf("sync config source %q: %w", src.Name, err)
+		}
+	}
+	return nil
+}
+
+func configSourceToDB(src config.SourceConfig) db.Source {
+	return db.Source{
+		Name:          src.Name,
+		Type:          src.Type,
+		URL:           src.URL,
+		Repo:          src.Repo,
+		Branch:        src.Branch,
+		BaseURL:       src.BaseURL,
+		SpaceKey:      src.SpaceKey,
+		Auth:          src.Auth,
+		CrawlSchedule: src.CrawlSchedule,
+		IncludePath:   src.IncludePath,
+		IncludePaths:  src.IncludePaths,
+	}
+}

--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -141,5 +141,6 @@ func sourceToConfig(src db.Source) config.SourceConfig {
 		SpaceKey:      src.SpaceKey,
 		CrawlSchedule: src.CrawlSchedule,
 		IncludePath:   src.IncludePath,
+		IncludePaths:  src.IncludePaths,
 	}
 }

--- a/internal/crawler/crawler_internal_test.go
+++ b/internal/crawler/crawler_internal_test.go
@@ -1,6 +1,7 @@
 package crawler
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/mathwro/DocuMcp/internal/db"
@@ -21,5 +22,20 @@ func TestSourceToConfig_github_repo_defaults_branch_to_main(t *testing.T) {
 func TestProviderForType_github_repo(t *testing.T) {
 	if providerForType("github_repo") != "github" {
 		t.Errorf("expected provider 'github' for github_repo")
+	}
+}
+
+func TestSourceToConfig_ForwardsIncludePaths(t *testing.T) {
+	got := sourceToConfig(db.Source{
+		Type:         "web",
+		URL:          "https://docs.example.com",
+		IncludePath:  "https://docs.example.com/legacy/",
+		IncludePaths: []string{"https://docs.example.com/guides/"},
+	})
+	if got.IncludePath != "https://docs.example.com/legacy/" {
+		t.Fatalf("IncludePath = %q", got.IncludePath)
+	}
+	if !reflect.DeepEqual(got.IncludePaths, []string{"https://docs.example.com/guides/"}) {
+		t.Fatalf("IncludePaths = %#v", got.IncludePaths)
 	}
 }

--- a/internal/crawler/crawler_internal_test.go
+++ b/internal/crawler/crawler_internal_test.go
@@ -4,7 +4,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/mathwro/DocuMcp/internal/config"
 	"github.com/mathwro/DocuMcp/internal/db"
+	"github.com/mathwro/DocuMcp/internal/testutil"
 )
 
 func TestSourceToConfig_github_repo_defaults_branch_to_main(t *testing.T) {
@@ -37,5 +39,35 @@ func TestSourceToConfig_ForwardsIncludePaths(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got.IncludePaths, []string{"https://docs.example.com/guides/"}) {
 		t.Fatalf("IncludePaths = %#v", got.IncludePaths)
+	}
+}
+
+func TestSyncConfigSources_InsertsConfigSourcesForUIList(t *testing.T) {
+	store := testutil.OpenStore(t)
+
+	cfg := &config.Config{Sources: []config.SourceConfig{
+		{
+			Name:         "Config Docs",
+			Type:         "web",
+			URL:          "https://docs.example.com",
+			IncludePaths: []string{"guides/", "reference/"},
+		},
+	}}
+	if err := SyncConfigSources(store, cfg); err != nil {
+		t.Fatalf("SyncConfigSources: %v", err)
+	}
+
+	sources, err := store.ListSources()
+	if err != nil {
+		t.Fatalf("ListSources: %v", err)
+	}
+	if len(sources) != 1 {
+		t.Fatalf("got %d sources, want 1", len(sources))
+	}
+	if sources[0].Name != "Config Docs" {
+		t.Fatalf("source name = %q", sources[0].Name)
+	}
+	if !reflect.DeepEqual(sources[0].IncludePaths, []string{"guides/", "reference/"}) {
+		t.Fatalf("IncludePaths = %#v", sources[0].IncludePaths)
 	}
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -247,6 +247,43 @@ func (s *Store) UpdateSourceConfig(id int64, src Source) error {
 	return nil
 }
 
+// UpsertSourceConfigByName inserts or updates a source declared in config.yaml.
+// It preserves crawl progress and timestamps for existing sources with the same name.
+func (s *Store) UpsertSourceConfigByName(src Source) (int64, error) {
+	id, err := s.GetSourceIDByName(src.Name)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return s.InsertSource(src)
+		}
+		return 0, fmt.Errorf("lookup config source %q: %w", src.Name, err)
+	}
+
+	paths := sourceIncludePaths(src)
+	pathsJSON, err := encodeIncludePaths(paths)
+	if err != nil {
+		return 0, fmt.Errorf("upsert config source %q include paths: %w", src.Name, err)
+	}
+	legacyPath := sourcepaths.First(paths)
+
+	res, err := s.db.Exec(
+		`UPDATE sources
+		 SET type = ?, url = ?, repo = ?, branch = ?, base_url = ?, space_key = ?, auth = ?, crawl_schedule = ?, include_path = ?, include_paths = ?
+		 WHERE id = ?`,
+		src.Type, src.URL, src.Repo, src.Branch, src.BaseURL, src.SpaceKey, src.Auth, src.CrawlSchedule, legacyPath, pathsJSON, id,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("upsert config source %q: %w", src.Name, err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("upsert config source %q rows affected: %w", src.Name, err)
+	}
+	if n == 0 {
+		return 0, fmt.Errorf("source %d: %w", id, ErrNotFound)
+	}
+	return id, nil
+}
+
 // UpdateSourcePageCount updates the page_count for a source.
 func (s *Store) UpdateSourcePageCount(id int64, count int) error {
 	_, err := s.db.Exec(

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -11,6 +11,8 @@ import (
 
 	vec "github.com/asg017/sqlite-vec-go-bindings/cgo"
 	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/mathwro/DocuMcp/internal/sourcepaths"
 )
 
 func init() {
@@ -41,6 +43,7 @@ type Source struct {
 	PageCount     int
 	CrawlTotal    int
 	IncludePath   string
+	IncludePaths  []string
 }
 
 // Page represents an indexed documentation page.
@@ -51,6 +54,47 @@ type Page struct {
 	Title    string
 	Content  string
 	Path     []string
+}
+
+func sourceIncludePaths(src Source) []string {
+	return sourcepaths.Normalize(src.IncludePath, src.IncludePaths)
+}
+
+func encodeIncludePaths(paths []string) (string, error) {
+	if paths == nil {
+		paths = []string{}
+	}
+	data, err := json.Marshal(paths)
+	if err != nil {
+		return "", fmt.Errorf("marshal include_paths: %w", err)
+	}
+	return string(data), nil
+}
+
+func decodeIncludePaths(raw string) ([]string, error) {
+	if raw == "" {
+		return []string{}, nil
+	}
+	var paths []string
+	if err := json.Unmarshal([]byte(raw), &paths); err != nil {
+		return nil, fmt.Errorf("unmarshal include_paths: %w", err)
+	}
+	if paths == nil {
+		paths = []string{}
+	}
+	return paths, nil
+}
+
+func hydrateIncludePaths(src *Source, raw string) error {
+	paths, err := decodeIncludePaths(raw)
+	if err != nil {
+		return err
+	}
+	src.IncludePaths = sourcepaths.Normalize(src.IncludePath, paths)
+	if src.IncludePath == "" {
+		src.IncludePath = sourcepaths.First(src.IncludePaths)
+	}
+	return nil
 }
 
 // Open opens (or creates) a SQLite database at dsn and applies the schema.
@@ -69,6 +113,7 @@ func Open(dsn string) (*Store, error) {
 	// Migrations for columns added after initial release.
 	_, _ = db.Exec(`ALTER TABLE sources ADD COLUMN crawl_total INTEGER NOT NULL DEFAULT 0`)
 	_, _ = db.Exec(`ALTER TABLE sources ADD COLUMN include_path TEXT NOT NULL DEFAULT ''`)
+	_, _ = db.Exec(`ALTER TABLE sources ADD COLUMN include_paths TEXT NOT NULL DEFAULT '[]'`)
 	_, _ = db.Exec(`ALTER TABLE sources ADD COLUMN branch TEXT NOT NULL DEFAULT ''`)
 	return &Store{db: db}, nil
 }
@@ -81,10 +126,17 @@ func (s *Store) DB() *sql.DB { return s.db }
 
 // InsertSource inserts a new source and returns its ID.
 func (s *Store) InsertSource(src Source) (int64, error) {
+	paths := sourceIncludePaths(src)
+	pathsJSON, err := encodeIncludePaths(paths)
+	if err != nil {
+		return 0, err
+	}
+	legacyPath := sourcepaths.First(paths)
+
 	res, err := s.db.Exec(
-		`INSERT INTO sources (name, type, url, repo, branch, base_url, space_key, auth, crawl_schedule, include_path)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		src.Name, src.Type, src.URL, src.Repo, src.Branch, src.BaseURL, src.SpaceKey, src.Auth, src.CrawlSchedule, src.IncludePath,
+		`INSERT INTO sources (name, type, url, repo, branch, base_url, space_key, auth, crawl_schedule, include_path, include_paths)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		src.Name, src.Type, src.URL, src.Repo, src.Branch, src.BaseURL, src.SpaceKey, src.Auth, src.CrawlSchedule, legacyPath, pathsJSON,
 	)
 	if err != nil {
 		return 0, fmt.Errorf("insert source: %w", err)
@@ -95,7 +147,7 @@ func (s *Store) InsertSource(src Source) (int64, error) {
 // ListSources returns all configured sources.
 func (s *Store) ListSources() ([]Source, error) {
 	rows, err := s.db.Query(
-		`SELECT id, name, type, url, repo, branch, base_url, space_key, auth, crawl_schedule, page_count, last_crawled, crawl_total, include_path
+		`SELECT id, name, type, url, repo, branch, base_url, space_key, auth, crawl_schedule, page_count, last_crawled, crawl_total, include_path, include_paths
 		 FROM sources ORDER BY id`,
 	)
 	if err != nil {
@@ -106,11 +158,15 @@ func (s *Store) ListSources() ([]Source, error) {
 	sources := make([]Source, 0)
 	for rows.Next() {
 		var src Source
+		var includePathsJSON string
 		if err := rows.Scan(
 			&src.ID, &src.Name, &src.Type, &src.URL, &src.Repo, &src.Branch,
-			&src.BaseURL, &src.SpaceKey, &src.Auth, &src.CrawlSchedule, &src.PageCount, &src.LastCrawled, &src.CrawlTotal, &src.IncludePath,
+			&src.BaseURL, &src.SpaceKey, &src.Auth, &src.CrawlSchedule, &src.PageCount, &src.LastCrawled, &src.CrawlTotal, &src.IncludePath, &includePathsJSON,
 		); err != nil {
 			return nil, fmt.Errorf("scan source: %w", err)
+		}
+		if err := hydrateIncludePaths(&src, includePathsJSON); err != nil {
+			return nil, fmt.Errorf("list sources include paths: %w", err)
 		}
 		sources = append(sources, src)
 	}
@@ -120,18 +176,22 @@ func (s *Store) ListSources() ([]Source, error) {
 // GetSource returns a single source by ID.
 func (s *Store) GetSource(id int64) (*Source, error) {
 	var src Source
+	var includePathsJSON string
 	err := s.db.QueryRow(
-		`SELECT id, name, type, url, repo, branch, base_url, space_key, auth, crawl_schedule, page_count, last_crawled, crawl_total, include_path
+		`SELECT id, name, type, url, repo, branch, base_url, space_key, auth, crawl_schedule, page_count, last_crawled, crawl_total, include_path, include_paths
 		 FROM sources WHERE id = ?`, id,
 	).Scan(
 		&src.ID, &src.Name, &src.Type, &src.URL, &src.Repo, &src.Branch,
-		&src.BaseURL, &src.SpaceKey, &src.Auth, &src.CrawlSchedule, &src.PageCount, &src.LastCrawled, &src.CrawlTotal, &src.IncludePath,
+		&src.BaseURL, &src.SpaceKey, &src.Auth, &src.CrawlSchedule, &src.PageCount, &src.LastCrawled, &src.CrawlTotal, &src.IncludePath, &includePathsJSON,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, fmt.Errorf("source %d: %w", id, ErrNotFound)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("get source %d: %w", id, err)
+	}
+	if err := hydrateIncludePaths(&src, includePathsJSON); err != nil {
+		return nil, fmt.Errorf("get source %d include paths: %w", id, err)
 	}
 	return &src, nil
 }
@@ -161,11 +221,18 @@ func (s *Store) DeleteSource(id int64) error {
 // UpdateSourceConfig updates editable source configuration fields.
 // It intentionally leaves type, auth, crawl progress, and timestamps unchanged.
 func (s *Store) UpdateSourceConfig(id int64, src Source) error {
+	paths := sourceIncludePaths(src)
+	pathsJSON, err := encodeIncludePaths(paths)
+	if err != nil {
+		return fmt.Errorf("update source config %d include paths: %w", id, err)
+	}
+	legacyPath := sourcepaths.First(paths)
+
 	res, err := s.db.Exec(
 		`UPDATE sources
-		 SET name = ?, url = ?, repo = ?, branch = ?, base_url = ?, space_key = ?, crawl_schedule = ?, include_path = ?
+		 SET name = ?, url = ?, repo = ?, branch = ?, base_url = ?, space_key = ?, crawl_schedule = ?, include_path = ?, include_paths = ?
 		 WHERE id = ?`,
-		src.Name, src.URL, src.Repo, src.Branch, src.BaseURL, src.SpaceKey, src.CrawlSchedule, src.IncludePath, id,
+		src.Name, src.URL, src.Repo, src.Branch, src.BaseURL, src.SpaceKey, src.CrawlSchedule, legacyPath, pathsJSON, id,
 	)
 	if err != nil {
 		return fmt.Errorf("update source config %d: %w", id, err)

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -195,6 +195,78 @@ func TestUpdateSourceConfig(t *testing.T) {
 	}
 }
 
+func TestUpsertSourceConfigByName_InsertsConfigSource(t *testing.T) {
+	store := testutil.OpenStore(t)
+
+	id, err := store.UpsertSourceConfigByName(db.Source{
+		Name:         "Config Docs",
+		Type:         "web",
+		URL:          "https://docs.example.com",
+		IncludePaths: []string{"guides/", "reference/"},
+	})
+	if err != nil {
+		t.Fatalf("UpsertSourceConfigByName: %v", err)
+	}
+	got, err := store.GetSource(id)
+	if err != nil {
+		t.Fatalf("GetSource: %v", err)
+	}
+	if got.Name != "Config Docs" || got.Type != "web" || got.URL != "https://docs.example.com" {
+		t.Fatalf("source = %#v", got)
+	}
+	if !reflect.DeepEqual(got.IncludePaths, []string{"guides/", "reference/"}) {
+		t.Fatalf("IncludePaths = %#v", got.IncludePaths)
+	}
+}
+
+func TestUpsertSourceConfigByName_UpdatesConfigSourceAndPreservesProgress(t *testing.T) {
+	store := testutil.OpenStore(t)
+
+	id, err := store.InsertSource(db.Source{
+		Name:          "Config Docs",
+		Type:          "web",
+		URL:           "https://old.example.com",
+		CrawlSchedule: "0 1 * * *",
+	})
+	if err != nil {
+		t.Fatalf("InsertSource: %v", err)
+	}
+	if err := store.UpdateSourcePageCount(id, 12); err != nil {
+		t.Fatalf("UpdateSourcePageCount: %v", err)
+	}
+
+	gotID, err := store.UpsertSourceConfigByName(db.Source{
+		Name:          "Config Docs",
+		Type:          "github_repo",
+		Repo:          "owner/repo",
+		Branch:        "develop",
+		IncludePaths:  []string{"docs/", "help/tests/"},
+		CrawlSchedule: "0 2 * * *",
+	})
+	if err != nil {
+		t.Fatalf("UpsertSourceConfigByName: %v", err)
+	}
+	if gotID != id {
+		t.Fatalf("id = %d, want existing id %d", gotID, id)
+	}
+	got, err := store.GetSource(id)
+	if err != nil {
+		t.Fatalf("GetSource: %v", err)
+	}
+	if got.Type != "github_repo" {
+		t.Fatalf("Type = %q, want github_repo", got.Type)
+	}
+	if got.Repo != "owner/repo" || got.Branch != "develop" {
+		t.Fatalf("repo/branch = %q/%q", got.Repo, got.Branch)
+	}
+	if got.PageCount != 12 || got.LastCrawled == nil {
+		t.Fatalf("progress not preserved: PageCount=%d LastCrawled=%v", got.PageCount, got.LastCrawled)
+	}
+	if !reflect.DeepEqual(got.IncludePaths, []string{"docs/", "help/tests/"}) {
+		t.Fatalf("IncludePaths = %#v", got.IncludePaths)
+	}
+}
+
 func TestUpdateSourcePageCount(t *testing.T) {
 	store := testutil.OpenStore(t)
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -3,6 +3,7 @@ package db_test
 import (
 	"encoding/json"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -341,5 +342,51 @@ func TestInsertSource_github_repo_persists_branch(t *testing.T) {
 	}
 	if got.IncludePath != "docs/" {
 		t.Errorf("IncludePath: got %q, want %q", got.IncludePath, "docs/")
+	}
+}
+
+func TestInsertSource_PersistsIncludePaths(t *testing.T) {
+	store := testutil.OpenStore(t)
+
+	id, err := store.InsertSource(db.Source{
+		Name:         "Docs",
+		Type:         "web",
+		URL:          "https://docs.example.com",
+		IncludePaths: []string{"https://docs.example.com/guides/", "https://docs.example.com/reference/"},
+	})
+	if err != nil {
+		t.Fatalf("InsertSource: %v", err)
+	}
+	got, err := store.GetSource(id)
+	if err != nil {
+		t.Fatalf("GetSource: %v", err)
+	}
+	want := []string{"https://docs.example.com/guides/", "https://docs.example.com/reference/"}
+	if !reflect.DeepEqual(got.IncludePaths, want) {
+		t.Fatalf("IncludePaths = %#v, want %#v", got.IncludePaths, want)
+	}
+	if got.IncludePath != want[0] {
+		t.Fatalf("IncludePath = %q, want first path %q", got.IncludePath, want[0])
+	}
+}
+
+func TestInsertSource_LegacyIncludePathPopulatesIncludePaths(t *testing.T) {
+	store := testutil.OpenStore(t)
+
+	id, err := store.InsertSource(db.Source{
+		Name:        "Docs",
+		Type:        "github_repo",
+		Repo:        "owner/repo",
+		IncludePath: "docs/",
+	})
+	if err != nil {
+		t.Fatalf("InsertSource: %v", err)
+	}
+	got, err := store.GetSource(id)
+	if err != nil {
+		t.Fatalf("GetSource: %v", err)
+	}
+	if !reflect.DeepEqual(got.IncludePaths, []string{"docs/"}) {
+		t.Fatalf("IncludePaths = %#v, want [docs/]", got.IncludePaths)
 	}
 }

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -16,6 +16,7 @@ CREATE TABLE IF NOT EXISTS sources (
     page_count     INTEGER NOT NULL DEFAULT 0,
     crawl_total    INTEGER NOT NULL DEFAULT 0,
     include_path   TEXT NOT NULL DEFAULT '',
+    include_paths  TEXT NOT NULL DEFAULT '[]',
     created_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -20,28 +20,30 @@ import (
 //   - BaseURL, SpaceKey: adapter-internal identifiers (URL already identifies the source)
 //   - CrawlSchedule: internal scheduling detail (LastCrawled gives staleness info)
 type sourceInfo struct {
-	ID          int64      `json:"id"`
-	Name        string     `json:"name"`
-	Type        string     `json:"type"`
-	URL         string     `json:"url"`
-	Repo        string     `json:"repo,omitempty"`
-	PageCount   int        `json:"pageCount"`
-	CrawlTotal  int        `json:"crawlTotal"`
-	LastCrawled *time.Time `json:"lastCrawled,omitempty"`
-	IncludePath string     `json:"includePath,omitempty"`
+	ID           int64      `json:"id"`
+	Name         string     `json:"name"`
+	Type         string     `json:"type"`
+	URL          string     `json:"url"`
+	Repo         string     `json:"repo,omitempty"`
+	PageCount    int        `json:"pageCount"`
+	CrawlTotal   int        `json:"crawlTotal"`
+	LastCrawled  *time.Time `json:"lastCrawled,omitempty"`
+	IncludePath  string     `json:"includePath,omitempty"`
+	IncludePaths []string   `json:"includePaths,omitempty"`
 }
 
 func toSourceInfo(s db.Source) sourceInfo {
 	return sourceInfo{
-		ID:          s.ID,
-		Name:        s.Name,
-		Type:        s.Type,
-		URL:         s.URL,
-		Repo:        s.Repo,
-		PageCount:   s.PageCount,
-		CrawlTotal:  s.CrawlTotal,
-		LastCrawled: s.LastCrawled,
-		IncludePath: s.IncludePath,
+		ID:           s.ID,
+		Name:         s.Name,
+		Type:         s.Type,
+		URL:          s.URL,
+		Repo:         s.Repo,
+		PageCount:    s.PageCount,
+		CrawlTotal:   s.CrawlTotal,
+		LastCrawled:  s.LastCrawled,
+		IncludePath:  s.IncludePath,
+		IncludePaths: s.IncludePaths,
 	}
 }
 

--- a/internal/sourcepaths/sourcepaths.go
+++ b/internal/sourcepaths/sourcepaths.go
@@ -1,0 +1,29 @@
+package sourcepaths
+
+import "strings"
+
+// Normalize combines the legacy single path with the multi-path list.
+// It trims blanks, drops empty entries, and deduplicates in first-seen order.
+func Normalize(legacy string, paths []string) []string {
+	out := make([]string, 0, len(paths)+1)
+	seen := make(map[string]struct{}, len(paths)+1)
+	for _, p := range append([]string{legacy}, paths...) {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if _, ok := seen[p]; ok {
+			continue
+		}
+		seen[p] = struct{}{}
+		out = append(out, p)
+	}
+	return out
+}
+
+func First(paths []string) string {
+	if len(paths) == 0 {
+		return ""
+	}
+	return paths[0]
+}

--- a/internal/sourcepaths/sourcepaths_test.go
+++ b/internal/sourcepaths/sourcepaths_test.go
@@ -1,0 +1,33 @@
+package sourcepaths
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNormalize_CombinesLegacyAndList(t *testing.T) {
+	got := Normalize(" docs/ ", []string{"examples/", "", "docs/", " api/ "})
+	want := []string{"docs/", "examples/", "api/"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Normalize() = %#v, want %#v", got, want)
+	}
+}
+
+func TestNormalize_EmptyReturnsEmptySlice(t *testing.T) {
+	got := Normalize("", nil)
+	if got == nil {
+		t.Fatal("Normalize returned nil, want empty slice")
+	}
+	if len(got) != 0 {
+		t.Fatalf("Normalize length = %d, want 0", len(got))
+	}
+}
+
+func TestFirst_ReturnsFirstOrEmpty(t *testing.T) {
+	if got := First([]string{"docs/", "api/"}); got != "docs/" {
+		t.Fatalf("First() = %q, want docs/", got)
+	}
+	if got := First(nil); got != "" {
+		t.Fatalf("First(nil) = %q, want empty", got)
+	}
+}

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -1,5 +1,16 @@
 function blankSource(type = 'web') {
-  return { Name: '', Type: type, URL: '', Repo: '', Branch: '', IncludePath: '', CrawlSchedule: '' }
+  return { Name: '', Type: type, URL: '', Repo: '', Branch: '', IncludePath: '', IncludePaths: [], CrawlSchedule: '' }
+}
+
+function sourceIncludePaths(src) {
+  const paths = Array.isArray(src.IncludePaths) ? src.IncludePaths : []
+  const combined = [src.IncludePath || '', ...paths]
+  return [...new Set(combined.map(p => (p || '').trim()).filter(Boolean))]
+}
+
+function prepareSourcePayload(src) {
+  const paths = sourceIncludePaths(src)
+  return { ...src, IncludePaths: paths, IncludePath: paths[0] || '' }
 }
 
 function app() {
@@ -59,7 +70,7 @@ function app() {
     },
 
     async addSource() {
-      const body = { ...this.newSource }
+      const body = prepareSourcePayload(this.newSource)
       try {
         const r = await fetch('/api/sources', {
           method: 'POST',
@@ -85,6 +96,7 @@ function app() {
         Repo: src.Repo || '',
         Branch: src.Branch || '',
         IncludePath: src.IncludePath || '',
+        IncludePaths: sourceIncludePaths(src),
         CrawlSchedule: src.CrawlSchedule || ''
       }
     },
@@ -95,7 +107,7 @@ function app() {
     },
 
     async updateSource(id) {
-      const body = { ...this.editSource }
+      const body = prepareSourcePayload(this.editSource)
       try {
         const r = await fetch(`/api/sources/${id}`, {
           method: 'PUT',
@@ -243,14 +255,40 @@ function app() {
       return map[type] || type
     },
 
+    includePathPlaceholder(type) {
+      return type === 'github_repo' ? 'docs/' : 'https://docs.example.com/guides/'
+    },
+
+    includePathHelp(type) {
+      if (type === 'github_repo') return 'Only files under these repository folders will be indexed. Leave empty to index the whole repo.'
+      return 'Only same-site URLs under these prefixes will be indexed. Leave empty to use the source URL path.'
+    },
+
+    ensureIncludePathRow(src) {
+      if (!Array.isArray(src.IncludePaths)) src.IncludePaths = []
+      if (src.IncludePaths.length === 0) src.IncludePaths.push('')
+    },
+
+    addIncludePathRow(src) {
+      if (!Array.isArray(src.IncludePaths)) src.IncludePaths = []
+      src.IncludePaths.push('')
+    },
+
+    removeIncludePathRow(src, index) {
+      if (!Array.isArray(src.IncludePaths)) src.IncludePaths = []
+      src.IncludePaths.splice(index, 1)
+    },
+
+    sourceDisplayPaths(src) {
+      return sourceIncludePaths(src).join(', ')
+    },
+
     sourceDisplayURL(src) {
       if (!src) return ''
       if (src.Type === 'github_wiki' && src.Repo) return `https://github.com/${src.Repo}/wiki`
       if (src.Type === 'github_repo' && src.Repo) {
         const branch = src.Branch || 'main'
-        const includePath = (src.IncludePath || '').replace(/^\/+|\/+$/g, '')
-        const base = `https://github.com/${src.Repo}/tree/${branch}`
-        return includePath ? `${base}/${includePath}` : base
+        return `https://github.com/${src.Repo}/tree/${branch}`
       }
       return src.URL || src.BaseURL || ''
     },

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -256,12 +256,12 @@ function app() {
     },
 
     includePathPlaceholder(type) {
-      return type === 'github_repo' ? 'docs/' : 'https://docs.example.com/guides/'
+      return type === 'github_repo' ? 'docs/' : '/guides/'
     },
 
     includePathHelp(type) {
       if (type === 'github_repo') return 'Only files under these repository folders will be indexed. Leave empty to index the whole repo.'
-      return 'Only same-site URLs under these prefixes will be indexed. Leave empty to use the source URL path.'
+      return 'Only same-site URLs under these path prefixes will be indexed. Use paths like /guides/ or guides/; full same-site URLs also work. Leave empty to use the source URL path.'
     },
 
     ensureIncludePathRow(src) {

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -36,10 +36,6 @@
         <template x-if="newSource.Type === 'web'">
           <input type="url" x-model="newSource.URL" placeholder="https://docs.example.com" />
         </template>
-        <template x-if="newSource.Type === 'web'">
-          <input type="url" x-model="newSource.IncludePath"
-                 placeholder="Restrict to path prefix (optional, e.g. https://docs.example.com/guide/)" />
-        </template>
         <template x-if="newSource.Type === 'github_wiki'">
           <input type="text" x-model="newSource.Repo" placeholder="owner/repo" />
         </template>
@@ -49,9 +45,20 @@
         <template x-if="newSource.Type === 'github_repo'">
           <input type="text" x-model="newSource.Branch" placeholder="Branch (default: main)" />
         </template>
-        <template x-if="newSource.Type === 'github_repo'">
-          <input type="text" x-model="newSource.IncludePath"
-                 placeholder="Subfolder prefix (optional, e.g. docs/)" />
+        <template x-if="newSource.Type === 'web' || newSource.Type === 'github_repo'">
+          <div class="path-scope" x-init="ensureIncludePathRow(newSource)">
+            <label>Crawl only these paths</label>
+            <p class="muted" x-text="includePathHelp(newSource.Type)"></p>
+            <template x-for="(_, index) in newSource.IncludePaths" :key="index">
+              <div class="path-row">
+                <input :type="newSource.Type === 'web' ? 'url' : 'text'"
+                       x-model="newSource.IncludePaths[index]"
+                       :placeholder="includePathPlaceholder(newSource.Type)" />
+                <button type="button" class="secondary" @click="removeIncludePathRow(newSource, index)">Remove</button>
+              </div>
+            </template>
+            <button type="button" class="secondary" @click="addIncludePathRow(newSource)">Add path</button>
+          </div>
         </template>
         <template x-if="newSource.Type === 'azure_devops'">
           <input type="url" x-model="newSource.URL" placeholder="https://dev.azure.com/org/project" />
@@ -123,10 +130,6 @@
             <template x-if="editSource.Type === 'web'">
               <input type="url" x-model="editSource.URL" placeholder="https://docs.example.com" />
             </template>
-            <template x-if="editSource.Type === 'web'">
-              <input type="url" x-model="editSource.IncludePath"
-                     placeholder="Restrict to path prefix (optional, e.g. https://docs.example.com/guide/)" />
-            </template>
             <template x-if="editSource.Type === 'github_wiki'">
               <input type="text" x-model="editSource.Repo" placeholder="owner/repo" />
             </template>
@@ -136,9 +139,20 @@
             <template x-if="editSource.Type === 'github_repo'">
               <input type="text" x-model="editSource.Branch" placeholder="Branch (default: main)" />
             </template>
-            <template x-if="editSource.Type === 'github_repo'">
-              <input type="text" x-model="editSource.IncludePath"
-                     placeholder="Subfolder prefix (optional, e.g. docs/)" />
+            <template x-if="editSource.Type === 'web' || editSource.Type === 'github_repo'">
+              <div class="path-scope">
+                <label>Crawl only these paths</label>
+                <p class="muted" x-text="includePathHelp(editSource.Type)"></p>
+                <template x-for="(_, index) in editSource.IncludePaths" :key="index">
+                  <div class="path-row">
+                    <input :type="editSource.Type === 'web' ? 'url' : 'text'"
+                           x-model="editSource.IncludePaths[index]"
+                           :placeholder="includePathPlaceholder(editSource.Type)" />
+                    <button type="button" class="secondary" @click="removeIncludePathRow(editSource, index)">Remove</button>
+                  </div>
+                </template>
+                <button type="button" class="secondary" @click="addIncludePathRow(editSource)">Add path</button>
+              </div>
             </template>
             <template x-if="editSource.Type === 'azure_devops'">
               <input type="url" x-model="editSource.URL" placeholder="https://dev.azure.com/org/project" />
@@ -154,6 +168,7 @@
               <span x-text="sourceTypeName(src.Type) + ': '"></span>
               <a :href="safeHref(sourceDisplayURL(src))" target="_blank" rel="noopener noreferrer" x-text="sourceDisplayURL(src)"></a>
             </div>
+            <div class="muted source-meta" x-show="sourceDisplayPaths(src)" x-text="'Crawls only: ' + sourceDisplayPaths(src)"></div>
             <div class="muted" x-show="src.LastCrawled" x-text="'Last crawled: ' + formatDate(src.LastCrawled)"></div>
             <div class="muted" x-show="!src.LastCrawled && !isCrawling(src)">Never crawled</div>
           </div>

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -51,7 +51,7 @@
             <p class="muted" x-text="includePathHelp(newSource.Type)"></p>
             <template x-for="(_, index) in newSource.IncludePaths" :key="index">
               <div class="path-row">
-                <input :type="newSource.Type === 'web' ? 'url' : 'text'"
+                <input type="text"
                        x-model="newSource.IncludePaths[index]"
                        :placeholder="includePathPlaceholder(newSource.Type)" />
                 <button type="button" class="secondary" @click="removeIncludePathRow(newSource, index)">Remove</button>
@@ -145,7 +145,7 @@
                 <p class="muted" x-text="includePathHelp(editSource.Type)"></p>
                 <template x-for="(_, index) in editSource.IncludePaths" :key="index">
                   <div class="path-row">
-                    <input :type="editSource.Type === 'web' ? 'url' : 'text'"
+                    <input type="text"
                            x-model="editSource.IncludePaths[index]"
                            :placeholder="includePathPlaceholder(editSource.Type)" />
                     <button type="button" class="secondary" @click="removeIncludePathRow(editSource, index)">Remove</button>

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -67,11 +67,17 @@ h2 { font-size: 1.1rem; font-weight: 600; }
 .path-row {
   display: flex;
   gap: 0.5rem;
-  align-items: center;
+  align-items: flex-start;
+  margin-bottom: 0.75rem;
 }
 
 .path-row input {
   flex: 1;
+  margin-bottom: 0;
+}
+
+.path-row button {
+  flex: 0 0 auto;
 }
 
 .device-code-box { background: var(--bg); border: 1px solid var(--border); border-radius: 6px; padding: 1rem; margin-top: 1rem; }

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -50,6 +50,30 @@ h2 { font-size: 1.1rem; font-weight: 600; }
 .source-meta a { color: inherit; text-decoration: none; }
 .source-meta a:hover { color: var(--accent-hover); text-decoration: underline; }
 
+.path-scope {
+  margin-bottom: 1rem;
+}
+
+.path-scope label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.35rem;
+}
+
+.path-scope .muted {
+  margin-bottom: 0.75rem;
+}
+
+.path-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.path-row input {
+  flex: 1;
+}
+
 .device-code-box { background: var(--bg); border: 1px solid var(--border); border-radius: 6px; padding: 1rem; margin-top: 1rem; }
 .device-code { font-size: 2rem; font-weight: 700; letter-spacing: 0.25em; color: var(--accent); margin: 0.5rem 0; }
 


### PR DESCRIPTION
## Summary
- Add include_paths support across config, SQLite persistence, API/MCP responses, crawler forwarding, and adapters.
- Scope web URLs and GitHub repo files against any configured path prefix while keeping include_path compatibility.
- Update the Web UI wording to 'Crawl only these paths' with multi-row path controls and refresh docs/examples.

## Test Plan
- CGO_ENABLED=1 go vet -tags sqlite_fts5 ./...
- CGO_ENABLED=1 go test -tags sqlite_fts5 -race ./...
- make build