### PR TITLE
docs: clarify API key environment behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ docker run -d `
 
 Open `http://localhost:8080`. Add a public web source from the UI and trigger a crawl. The `documcp-data` named volume preserves your indexed content and any tokens you store across restarts.
 
+If you previously started this container with `DOCUMCP_API_KEY` set and want to return to local-only unauthenticated access, remove that environment variable and recreate the container. `docker stop` / `docker start` keeps the old container environment:
+
+```bash
+docker rm -f documcp
+docker run -d \
+  --name documcp \
+  -p 8080:8080 \
+  -v documcp-data:/app/data \
+  ghcr.io/mathwro/documcp:latest
+```
+
 For private sources, exposing the port to your LAN, declarative source seeding via `config.yaml`, or building from source, see **[docs/install.md](docs/install.md)**.
 
 ### AI-assisted setup

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -68,3 +68,7 @@ If you do expose DocuMcp beyond a single local user:
    proxy reach it over loopback or a private network.
 4. Set `DOCUMCP_SECRET_KEY` to a persistent 32-byte value so stored
    tokens survive restarts; back the SQLite data volume up.
+
+`DOCUMCP_API_KEY` and `DOCUMCP_SECRET_KEY` are environment variables, not
+`config.yaml` fields. Treat them as deployment secrets and inject them with
+Compose, systemd, Kubernetes, or a secret manager.

--- a/cmd/documcp/main.go
+++ b/cmd/documcp/main.go
@@ -83,8 +83,8 @@ func main() {
 	mcpServer := mcp.NewServer(store, embedder)
 	apiServer := api.NewServerWithMCPHandlers(store, c, mcpServer.Handler(), mcpServer.StreamableHTTPHandler(), key)
 
-	// Warn if no API key is configured — the API and MCP endpoints are open.
-	api.LogAPIKeyWarning()
+	// Log whether API/MCP bearer-token auth is enabled.
+	api.LogAPIKeyStatus()
 
 	addr := bindAddr(cfg.Server.Port)
 	slog.Info("starting DocuMcp", "addr", addr)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,8 +1,10 @@
 # Configuration
 
-DocuMcp reads its configuration from an optional YAML file and a small set of environment variables. If no config file is present, the server starts with built-in defaults (`port: 8080`, `data_dir: /app/data`, no declarative sources) and all source management happens through the Web UI — those sources persist in the SQLite database under `data_dir`.
+DocuMcp reads source and app configuration from an optional YAML file, and deployment secrets from environment variables. If no config file is present, the server starts with built-in defaults (`port: 8080`, `data_dir: /app/data`, no declarative sources) and all source management happens through the Web UI — those sources persist in the SQLite database under `data_dir`.
 
 Provide a `config.yaml` when you want to declare sources and crawl schedules in version control. The file watcher reloads it on save, so changes take effect without a restart. UI-added sources are stored in the database, not written back to YAML.
+
+Secrets are intentionally not read from `config.yaml`. `DOCUMCP_API_KEY` and `DOCUMCP_SECRET_KEY` come from the process environment so they work with Docker Compose, Kubernetes, systemd, and secret managers without encouraging secrets in a git-tracked YAML file. Changing those values requires recreating or restarting the process with a new environment.
 
 `DOCUMCP_CONFIG` lets you override the path. When it is set, the file must exist (typos fail loudly); when it is unset, a missing file silently falls back to defaults.
 
@@ -26,8 +28,8 @@ See [sources.md](sources.md) for a per-type breakdown with examples.
 
 | Variable | Description |
 |---|---|
-| `DOCUMCP_SECRET_KEY` | 32-byte hex key for encrypting stored GitHub PATs and Azure DevOps OAuth tokens in SQLite. If unset, a random key is generated per run (tokens lost on restart). Only relevant if you use authenticated sources. |
-| `DOCUMCP_API_KEY` | Bearer token required on `/api/*` and `/mcp/*` endpoints. If unset, all endpoints are unauthenticated (warns at startup). See [install.md](install.md#when-to-set-documcp_api_key) for when to enable this. |
+| `DOCUMCP_SECRET_KEY` | 32-byte hex key for encrypting stored GitHub PATs and Azure DevOps OAuth tokens in SQLite. If unset, a random key is generated per run (tokens lost on restart). Only relevant if you use authenticated sources. Not read from `config.yaml`. |
+| `DOCUMCP_API_KEY` | Bearer token required on `/api/*` and `/mcp/*` endpoints. If unset, all endpoints are unauthenticated (warns at startup). See [install.md](install.md#when-to-set-documcp_api_key) for when to enable this. Not read from `config.yaml`. |
 | `DOCUMCP_CONFIG` | Path to config file (default: `config.yaml`) |
 | `DOCUMCP_MODEL_PATH` | Path to the ONNX model directory |
 | `DOCUMCP_BIND_ADDR` | Address to listen on. Defaults to `127.0.0.1:<port>` so a fresh install is not reachable from the network. The Docker image sets this to `0.0.0.0:8080` so the container's port mapping works; when running the binary directly, set `DOCUMCP_BIND_ADDR=0.0.0.0:8080` to expose it on the LAN. |

--- a/docs/install.md
+++ b/docs/install.md
@@ -85,6 +85,8 @@ docker compose up -d # or: podman compose up -d
 
 `DOCUMCP_API_KEY` is a bearer token enforced on every `/api/*` and `/mcp/*` request. It is **off by default** because the typical deployment is a single-user container bound to `127.0.0.1`, where the host's own permissions are the security boundary.
 
+This key is a deployment secret, not a `config.yaml` setting. The container reads it from the process environment at startup. If you remove or change it in `.env`, recreate the container so Docker/Compose starts DocuMcp with the new environment.
+
 | Situation | API key needed? |
 |---|---|
 | Single user, container on `localhost`, default `127.0.0.1` bind | No |
@@ -100,3 +102,9 @@ echo "DOCUMCP_API_KEY=$(openssl rand -hex 32)" >> .env
 ```
 
 Then include it in every MCP client config — see [mcp-clients.md](mcp-clients.md). The startup log warns if the key is unset, which is expected for the local-only case.
+
+To disable bearer auth for local-only use, remove `DOCUMCP_API_KEY` from `.env` or your Compose/service definition, then recreate the container:
+
+```bash
+docker compose up -d --force-recreate
+```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -6,6 +6,20 @@ Common symptoms and how to diagnose them. If your issue is not listed, check the
 
 `DOCUMCP_API_KEY` is set — every request needs `Authorization: Bearer <key>`. Unset it for local-only use, or pass the header from your MCP client. See [install.md](install.md#when-to-set-documcp_api_key) for guidance on when the key is appropriate.
 
+`config.yaml` does not control this key. Docker/Compose injects `DOCUMCP_API_KEY` into the container environment when the container is created, so removing `config.yaml` will not disable bearer auth.
+
+Check the running container:
+
+```bash
+docker compose exec documcp sh -lc 'test -n "$DOCUMCP_API_KEY" && echo DOCUMCP_API_KEY=set || echo DOCUMCP_API_KEY=unset'
+```
+
+If it is set and you want local-only unauthenticated access, remove `DOCUMCP_API_KEY` from `.env` or your Compose/service definition, then recreate the container:
+
+```bash
+docker compose up -d --force-recreate
+```
+
 ## The UI loads but `/api/sources` returns 404 in docker-compose
 
 Check `docker compose logs documcp`. The binary inside the container binds to `0.0.0.0:8080` (the image sets `DOCUMCP_BIND_ADDR`); if you changed the port in `config.yaml`, also update the compose `ports:` mapping and — if running outside compose — set `DOCUMCP_BIND_ADDR=0.0.0.0:<new-port>`.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -178,10 +178,12 @@ func isLoopbackOrigin(origin string) bool {
 	return ip != nil && ip.IsLoopback()
 }
 
-// logAPIKeyWarning logs a startup warning when no API key is configured.
+// LogAPIKeyStatus logs whether API/MCP bearer-token auth is enabled.
 // Call once from main after creating the server.
-func LogAPIKeyWarning() {
-	if os.Getenv("DOCUMCP_API_KEY") == "" {
+func LogAPIKeyStatus() {
+	if os.Getenv("DOCUMCP_API_KEY") != "" {
+		slog.Info("DOCUMCP_API_KEY set — API and MCP endpoints require Authorization: Bearer <key>")
+	} else {
 		slog.Warn("DOCUMCP_API_KEY not set — API and MCP endpoints are unauthenticated")
 	}
 }


### PR DESCRIPTION
## Summary
- Clarify that DOCUMCP_API_KEY and DOCUMCP_SECRET_KEY are environment-managed deployment secrets, not config.yaml fields.
- Add Quick Start, install, troubleshooting, and security notes about recreating containers after removing or changing DOCUMCP_API_KEY.
- Log whether API/MCP bearer auth is enabled at startup without printing the key.

## Root Cause
Docker keeps a container's environment in container metadata. Restarting an existing container does not re-read the host .env file, so a previously-created container can continue enforcing DOCUMCP_API_KEY until it is recreated.

## Validation
- git diff --check
- CGO_ENABLED=1 go test -tags sqlite_fts5 ./internal/api