### PR TITLE
[codex] export sources as yaml

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,7 @@
 
 DocuMcp reads source and app configuration from an optional YAML file, and deployment secrets from environment variables. If no config file is present, the server starts with built-in defaults (`port: 8080`, `data_dir: /app/data`, no declarative sources) and all source management happens through the Web UI — those sources persist in the SQLite database under `data_dir`.
 
-Provide a `config.yaml` when you want to declare sources and crawl schedules in version control. Config-declared sources are mirrored into SQLite so they appear in the Web UI and API source listings. The file watcher reloads YAML on save, so source changes take effect without a restart. UI-added sources are stored in the database, not written back to YAML.
+Provide a `config.yaml` when you want to declare sources and crawl schedules in version control. Config-declared sources are mirrored into SQLite so they appear in the Web UI and API source listings. The file watcher reloads YAML on save, so source changes take effect without a restart. UI-added sources are stored in the database and can be exported from the Web UI as a `sources:` YAML block; DocuMcp does not silently rewrite your mounted config file.
 
 Secrets are intentionally not read from `config.yaml`. `DOCUMCP_API_KEY` and `DOCUMCP_SECRET_KEY` come from the process environment so they work with Docker Compose, Kubernetes, systemd, and secret managers without encouraging secrets in a git-tracked YAML file. Changing those values requires recreating or restarting the process with a new environment.
 

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -1,6 +1,6 @@
 # Source Types
 
-DocuMcp supports four source adapters. Each is configured as an entry under `sources:` in `config.yaml`, or added through the Web UI.
+DocuMcp supports four source adapters. Each is configured as an entry under `sources:` in `config.yaml`, or added through the Web UI. The source list shows whether each source came from `config.yaml` or the UI. Use **Export YAML** in the Web UI to generate a portable `sources:` block from the current database state.
 
 ## Web (`type: web`)
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -13,9 +13,11 @@ import (
 	"time"
 
 	"github.com/mathwro/DocuMcp/internal/auth"
+	"github.com/mathwro/DocuMcp/internal/config"
 	"github.com/mathwro/DocuMcp/internal/db"
 	"github.com/mathwro/DocuMcp/internal/search"
 	"github.com/mathwro/DocuMcp/internal/sourcepaths"
+	"gopkg.in/yaml.v3"
 )
 
 // writeJSON writes v as JSON to w with the given status code.
@@ -117,6 +119,50 @@ func (s *Server) listSources(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, result)
 }
 
+type sourcesExport struct {
+	Sources []config.SourceConfig `yaml:"sources"`
+}
+
+func sourceConfigForExport(src db.Source) config.SourceConfig {
+	return config.SourceConfig{
+		Name:          src.Name,
+		Type:          src.Type,
+		Repo:          src.Repo,
+		Branch:        src.Branch,
+		URL:           src.URL,
+		BaseURL:       src.BaseURL,
+		SpaceKey:      src.SpaceKey,
+		CrawlSchedule: src.CrawlSchedule,
+		IncludePaths:  sourcepaths.Normalize(src.IncludePath, src.IncludePaths),
+	}
+}
+
+// exportSources handles GET /api/sources/export.
+// It emits portable YAML for source configuration only, excluding auth secrets
+// and runtime crawl state.
+func (s *Server) exportSources(w http.ResponseWriter, r *http.Request) {
+	sources, err := s.store.ListSources()
+	if err != nil {
+		internalError(w, "export sources", err)
+		return
+	}
+	out := sourcesExport{Sources: make([]config.SourceConfig, 0, len(sources))}
+	for _, src := range sources {
+		out.Sources = append(out.Sources, sourceConfigForExport(src))
+	}
+	data, err := yaml.Marshal(out)
+	if err != nil {
+		internalError(w, "marshal sources export", err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/x-yaml; charset=utf-8")
+	w.Header().Set("Content-Disposition", `attachment; filename="documcp-sources.yaml"`)
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(data); err != nil {
+		slog.Error("write sources export", "err", err)
+	}
+}
+
 // createSource handles POST /api/sources.
 // Decodes a db.Source from the request body, inserts it, and returns 201 with the created source.
 func (s *Server) createSource(w http.ResponseWriter, r *http.Request) {
@@ -133,6 +179,7 @@ func (s *Server) createSource(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	src.Origin = db.SourceOriginUI
 
 	id, err := s.store.InsertSource(src)
 	if err != nil {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -7,10 +7,13 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/mathwro/DocuMcp/internal/api"
 	"github.com/mathwro/DocuMcp/internal/auth"
+	"github.com/mathwro/DocuMcp/internal/config"
+	"github.com/mathwro/DocuMcp/internal/crawler"
 	"github.com/mathwro/DocuMcp/internal/db"
 	"github.com/mathwro/DocuMcp/internal/testutil"
 )
@@ -68,6 +71,103 @@ func TestListSources(t *testing.T) {
 	}
 }
 
+func TestListSources_IncludesOrigin(t *testing.T) {
+	store := openTestStore(t)
+
+	if _, err := store.InsertSource(db.Source{Name: "UI Docs", Type: "web"}); err != nil {
+		t.Fatalf("InsertSource: %v", err)
+	}
+	if err := crawler.SyncConfigSources(store, &config.Config{Sources: []config.SourceConfig{
+		{Name: "Config Docs", Type: "web", URL: "https://docs.example.com"},
+	}}); err != nil {
+		t.Fatalf("SyncConfigSources: %v", err)
+	}
+
+	srv := api.NewServer(store, nil, nil, make([]byte, 32))
+	r := httptest.NewRequest(http.MethodGet, "/api/sources", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var sources []map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&sources); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	got := make(map[string]string, len(sources))
+	for _, src := range sources {
+		name, ok := src["Name"].(string)
+		if !ok {
+			t.Fatalf("source missing Name string: %#v", src)
+		}
+		origin, ok := src["Origin"].(string)
+		if !ok {
+			t.Fatalf("source %q missing Origin string: %#v", name, src)
+		}
+		got[name] = origin
+	}
+	if got["UI Docs"] != "ui" {
+		t.Fatalf("UI Docs origin = %q, want ui", got["UI Docs"])
+	}
+	if got["Config Docs"] != "config" {
+		t.Fatalf("Config Docs origin = %q, want config", got["Config Docs"])
+	}
+}
+
+func TestExportSourcesYAML(t *testing.T) {
+	store := openTestStore(t)
+
+	if _, err := store.InsertSource(db.Source{
+		Name:          "UI Docs",
+		Type:          "web",
+		URL:           "https://ui.example.com",
+		Auth:          "legacy-secret",
+		CrawlSchedule: "0 2 * * *",
+		IncludePaths:  []string{"/guides/", "/reference/"},
+	}); err != nil {
+		t.Fatalf("InsertSource: %v", err)
+	}
+	if err := crawler.SyncConfigSources(store, &config.Config{Sources: []config.SourceConfig{
+		{Name: "Config Repo", Type: "github_repo", Repo: "owner/repo", Branch: "develop", IncludePaths: []string{"docs/"}},
+	}}); err != nil {
+		t.Fatalf("SyncConfigSources: %v", err)
+	}
+
+	srv := api.NewServer(store, nil, nil, make([]byte, 32))
+	r := httptest.NewRequest(http.MethodGet, "/api/sources/export", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("Content-Type"); got != "application/x-yaml; charset=utf-8" {
+		t.Fatalf("Content-Type = %q", got)
+	}
+	body := w.Body.String()
+	for _, want := range []string{
+		"sources:",
+		"name: UI Docs",
+		"url: https://ui.example.com",
+		"crawl_schedule: 0 2 * * *",
+		"name: Config Repo",
+		"repo: owner/repo",
+		"branch: develop",
+		"include_paths:",
+		"- docs/",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("export body missing %q:\n%s", want, body)
+		}
+	}
+	for _, forbidden := range []string{"legacy-secret", "auth:", "last_crawled", "page_count", "crawl_total"} {
+		if strings.Contains(body, forbidden) {
+			t.Fatalf("export body contains %q:\n%s", forbidden, body)
+		}
+	}
+}
+
 func TestCreateSource(t *testing.T) {
 	store := openTestStore(t)
 	srv := api.NewServer(store, nil, nil, make([]byte, 32))
@@ -104,6 +204,32 @@ func TestCreateSource(t *testing.T) {
 	}
 	if len(sources) != 1 {
 		t.Errorf("expected 1 source in store, got %d", len(sources))
+	}
+}
+
+func TestCreateSource_ForcesUIOrigin(t *testing.T) {
+	store := openTestStore(t)
+	srv := api.NewServer(store, nil, nil, make([]byte, 32))
+
+	body, err := json.Marshal(db.Source{Name: "NewDocs", Type: "web", URL: "https://example.com", Origin: db.SourceOriginConfig})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	r := httptest.NewRequest(http.MethodPost, "/api/sources", bytes.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, r)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var created db.Source
+	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if created.Origin != db.SourceOriginUI {
+		t.Fatalf("Origin = %q, want %q", created.Origin, db.SourceOriginUI)
 	}
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -84,6 +84,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) routes() {
 	s.mux.HandleFunc("GET /api/sources", s.listSources)
+	s.mux.HandleFunc("GET /api/sources/export", s.exportSources)
 	s.mux.HandleFunc("POST /api/sources", s.createSource)
 	s.mux.HandleFunc("PUT /api/sources/{id}", s.updateSource)
 	s.mux.HandleFunc("DELETE /api/sources/{id}", s.deleteSource)

--- a/internal/crawler/config_sources.go
+++ b/internal/crawler/config_sources.go
@@ -31,5 +31,6 @@ func configSourceToDB(src config.SourceConfig) db.Source {
 		CrawlSchedule: src.CrawlSchedule,
 		IncludePath:   src.IncludePath,
 		IncludePaths:  src.IncludePaths,
+		Origin:        db.SourceOriginConfig,
 	}
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -22,6 +22,11 @@ func init() {
 // ErrNotFound is returned when a requested record does not exist.
 var ErrNotFound = errors.New("not found")
 
+const (
+	SourceOriginUI     = "ui"
+	SourceOriginConfig = "config"
+)
+
 // Store wraps a SQLite database and exposes DocuMcp data operations.
 type Store struct {
 	db *sql.DB
@@ -44,6 +49,7 @@ type Source struct {
 	CrawlTotal    int
 	IncludePath   string
 	IncludePaths  []string
+	Origin        string
 }
 
 // Page represents an indexed documentation page.
@@ -115,6 +121,7 @@ func Open(dsn string) (*Store, error) {
 	_, _ = db.Exec(`ALTER TABLE sources ADD COLUMN include_path TEXT NOT NULL DEFAULT ''`)
 	_, _ = db.Exec(`ALTER TABLE sources ADD COLUMN include_paths TEXT NOT NULL DEFAULT '[]'`)
 	_, _ = db.Exec(`ALTER TABLE sources ADD COLUMN branch TEXT NOT NULL DEFAULT ''`)
+	_, _ = db.Exec(`ALTER TABLE sources ADD COLUMN origin TEXT NOT NULL DEFAULT 'ui'`)
 	return &Store{db: db}, nil
 }
 
@@ -132,11 +139,15 @@ func (s *Store) InsertSource(src Source) (int64, error) {
 		return 0, err
 	}
 	legacyPath := sourcepaths.First(paths)
+	origin := src.Origin
+	if origin == "" {
+		origin = SourceOriginUI
+	}
 
 	res, err := s.db.Exec(
-		`INSERT INTO sources (name, type, url, repo, branch, base_url, space_key, auth, crawl_schedule, include_path, include_paths)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		src.Name, src.Type, src.URL, src.Repo, src.Branch, src.BaseURL, src.SpaceKey, src.Auth, src.CrawlSchedule, legacyPath, pathsJSON,
+		`INSERT INTO sources (name, type, url, repo, branch, base_url, space_key, auth, crawl_schedule, include_path, include_paths, origin)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		src.Name, src.Type, src.URL, src.Repo, src.Branch, src.BaseURL, src.SpaceKey, src.Auth, src.CrawlSchedule, legacyPath, pathsJSON, origin,
 	)
 	if err != nil {
 		return 0, fmt.Errorf("insert source: %w", err)
@@ -147,7 +158,7 @@ func (s *Store) InsertSource(src Source) (int64, error) {
 // ListSources returns all configured sources.
 func (s *Store) ListSources() ([]Source, error) {
 	rows, err := s.db.Query(
-		`SELECT id, name, type, url, repo, branch, base_url, space_key, auth, crawl_schedule, page_count, last_crawled, crawl_total, include_path, include_paths
+		`SELECT id, name, type, url, repo, branch, base_url, space_key, auth, crawl_schedule, page_count, last_crawled, crawl_total, include_path, include_paths, origin
 		 FROM sources ORDER BY id`,
 	)
 	if err != nil {
@@ -161,7 +172,7 @@ func (s *Store) ListSources() ([]Source, error) {
 		var includePathsJSON string
 		if err := rows.Scan(
 			&src.ID, &src.Name, &src.Type, &src.URL, &src.Repo, &src.Branch,
-			&src.BaseURL, &src.SpaceKey, &src.Auth, &src.CrawlSchedule, &src.PageCount, &src.LastCrawled, &src.CrawlTotal, &src.IncludePath, &includePathsJSON,
+			&src.BaseURL, &src.SpaceKey, &src.Auth, &src.CrawlSchedule, &src.PageCount, &src.LastCrawled, &src.CrawlTotal, &src.IncludePath, &includePathsJSON, &src.Origin,
 		); err != nil {
 			return nil, fmt.Errorf("scan source: %w", err)
 		}
@@ -178,11 +189,11 @@ func (s *Store) GetSource(id int64) (*Source, error) {
 	var src Source
 	var includePathsJSON string
 	err := s.db.QueryRow(
-		`SELECT id, name, type, url, repo, branch, base_url, space_key, auth, crawl_schedule, page_count, last_crawled, crawl_total, include_path, include_paths
+		`SELECT id, name, type, url, repo, branch, base_url, space_key, auth, crawl_schedule, page_count, last_crawled, crawl_total, include_path, include_paths, origin
 		 FROM sources WHERE id = ?`, id,
 	).Scan(
 		&src.ID, &src.Name, &src.Type, &src.URL, &src.Repo, &src.Branch,
-		&src.BaseURL, &src.SpaceKey, &src.Auth, &src.CrawlSchedule, &src.PageCount, &src.LastCrawled, &src.CrawlTotal, &src.IncludePath, &includePathsJSON,
+		&src.BaseURL, &src.SpaceKey, &src.Auth, &src.CrawlSchedule, &src.PageCount, &src.LastCrawled, &src.CrawlTotal, &src.IncludePath, &includePathsJSON, &src.Origin,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, fmt.Errorf("source %d: %w", id, ErrNotFound)
@@ -267,9 +278,9 @@ func (s *Store) UpsertSourceConfigByName(src Source) (int64, error) {
 
 	res, err := s.db.Exec(
 		`UPDATE sources
-		 SET type = ?, url = ?, repo = ?, branch = ?, base_url = ?, space_key = ?, auth = ?, crawl_schedule = ?, include_path = ?, include_paths = ?
+		 SET type = ?, url = ?, repo = ?, branch = ?, base_url = ?, space_key = ?, auth = ?, crawl_schedule = ?, include_path = ?, include_paths = ?, origin = ?
 		 WHERE id = ?`,
-		src.Type, src.URL, src.Repo, src.Branch, src.BaseURL, src.SpaceKey, src.Auth, src.CrawlSchedule, legacyPath, pathsJSON, id,
+		src.Type, src.URL, src.Repo, src.Branch, src.BaseURL, src.SpaceKey, src.Auth, src.CrawlSchedule, legacyPath, pathsJSON, SourceOriginConfig, id,
 	)
 	if err != nil {
 		return 0, fmt.Errorf("upsert config source %q: %w", src.Name, err)

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -17,6 +17,7 @@ CREATE TABLE IF NOT EXISTS sources (
     crawl_total    INTEGER NOT NULL DEFAULT 0,
     include_path   TEXT NOT NULL DEFAULT '',
     include_paths  TEXT NOT NULL DEFAULT '[]',
+    origin         TEXT NOT NULL DEFAULT 'ui',
     created_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -127,6 +127,24 @@ function app() {
       await this.loadSources()
     },
 
+    async exportSources() {
+      try {
+        const r = await fetch('/api/sources/export')
+        if (!r.ok) { alert('Failed to export sources: ' + await r.text()); return }
+        const blob = await r.blob()
+        const url = URL.createObjectURL(blob)
+        const a = document.createElement('a')
+        a.href = url
+        a.download = 'documcp-sources.yaml'
+        document.body.appendChild(a)
+        a.click()
+        a.remove()
+        URL.revokeObjectURL(url)
+      } catch(e) {
+        console.error('exportSources:', e)
+      }
+    },
+
     async connectAuth(id, sourceType, sourceName) {
       // GitHub sources use a user-supplied fine-grained PAT.
       if (sourceType === 'github_wiki' || sourceType === 'github_repo') {
@@ -253,6 +271,10 @@ function app() {
     sourceTypeName(type) {
       const map = { web: 'Web', github_wiki: 'GitHub Wiki', github_repo: 'GitHub Repo', azure_devops: 'Azure DevOps' }
       return map[type] || type
+    },
+
+    sourceOriginName(origin) {
+      return origin === 'config' ? 'Config' : 'UI'
     },
 
     includePathPlaceholder(type) {

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -20,7 +20,10 @@
     <div x-show="view==='sources'" x-cloak>
       <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:1.5rem">
         <h1>Documentation Sources</h1>
-        <button @click="showAddForm=!showAddForm">+ Add Source</button>
+        <div class="actions">
+          <button class="secondary" @click="exportSources()">Export YAML</button>
+          <button @click="showAddForm=!showAddForm">+ Add Source</button>
+        </div>
       </div>
 
       <!-- Add Source Form -->
@@ -111,6 +114,7 @@
               <span class="badge" :class="isCrawling(src) ? 'badge-crawling' : (src.PageCount > 0 ? 'badge-ok' : 'badge-pending')"
                     x-text="isCrawling(src) ? '⟳ ' + src.PageCount + (src.CrawlTotal > 0 ? ' / ' + src.CrawlTotal : '') + ' pages' : src.PageCount + ' pages'"></span>
               <span class="badge badge-pending" x-text="sourceTypeName(src.Type)"></span>
+              <span class="badge" :class="src.Origin === 'config' ? 'badge-config' : 'badge-ui'" x-text="sourceOriginName(src.Origin)"></span>
             </div>
             <div class="actions">
               <button class="secondary" @click="connectAuth(src.ID, src.Type, src.Name)" x-show="src.Type !== 'web'">Connect</button>
@@ -169,6 +173,8 @@
               <a :href="safeHref(sourceDisplayURL(src))" target="_blank" rel="noopener noreferrer" x-text="sourceDisplayURL(src)"></a>
             </div>
             <div class="muted source-meta" x-show="sourceDisplayPaths(src)" x-text="'Crawls only: ' + sourceDisplayPaths(src)"></div>
+            <div class="muted" x-show="src.Origin === 'config'">Managed from config.yaml</div>
+            <div class="muted" x-show="src.Origin !== 'config'">Added through the UI</div>
             <div class="muted" x-show="src.LastCrawled" x-text="'Last crawled: ' + formatDate(src.LastCrawled)"></div>
             <div class="muted" x-show="!src.LastCrawled && !isCrawling(src)">Never crawled</div>
           </div>

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -27,6 +27,8 @@ body { background: var(--bg); color: var(--text); font-family: 'Inter', system-u
 .badge-pending { background: rgba(245,158,11,0.15); color: var(--warning); }
 .badge-error { background: rgba(239,68,68,0.15); color: var(--danger); }
 .badge-crawling { background: rgba(99,102,241,0.15); color: #818cf8; }
+.badge-config { background: rgba(14,165,233,0.15); color: #38bdf8; }
+.badge-ui { background: rgba(148,163,184,0.15); color: #cbd5e1; }
 
 button { background: var(--accent); color: white; border: none; padding: 0.5rem 1rem; border-radius: 6px; cursor: pointer; font-size: 0.875rem; transition: background 0.15s; }
 button:hover { background: var(--accent-hover); }


### PR DESCRIPTION
## Summary
- track whether sources come from config or the UI
- add a YAML export endpoint and Web UI export button
- document the source origin and export workflow

## Validation
- CGO_ENABLED=1 go test -tags sqlite_fts5 ./...
- node --check web/static/app.js
- git diff --check