### PR TITLE
test: expand coverage for core packages

### DIFF
--- a/cmd/bench/main_test.go
+++ b/cmd/bench/main_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestLoadTasksJSONL(t *testing.T) {
@@ -28,6 +31,70 @@ func TestLoadTasksJSONL(t *testing.T) {
 	}
 	if tasks[1].Source != "Go" {
 		t.Fatalf("expected source Go, got %q", tasks[1].Source)
+	}
+}
+
+func TestParseFlagsValidation(t *testing.T) {
+	if _, err := parseFlags(nil); err == nil || !strings.Contains(err.Error(), "-tasks is required") {
+		t.Fatalf("parseFlags without tasks error = %v, want -tasks required", err)
+	}
+	if _, err := parseFlags([]string{"-tasks", "tasks.jsonl", "-runs", "0"}); err == nil || !strings.Contains(err.Error(), "-runs") {
+		t.Fatalf("parseFlags invalid runs error = %v, want runs validation", err)
+	}
+	if _, err := parseFlags([]string{"-tasks", "tasks.jsonl", "-mode", "unknown"}); err == nil || !strings.Contains(err.Error(), "unsupported -mode") {
+		t.Fatalf("parseFlags invalid mode error = %v, want unsupported mode", err)
+	}
+
+	cfg, err := parseFlags([]string{"-tasks", "tasks.jsonl", "-mode", "native", "-runs", "2", "-timeout", "5s", "-dry-run"})
+	if err != nil {
+		t.Fatalf("parseFlags valid args: %v", err)
+	}
+	if cfg.TasksPath != "tasks.jsonl" || cfg.Mode != "native" || cfg.Runs != 2 || cfg.Timeout != 5*time.Second || !cfg.DryRun {
+		t.Fatalf("unexpected parsed config: %+v", cfg)
+	}
+}
+
+func TestRunDryRunWritesReport(t *testing.T) {
+	dir := t.TempDir()
+	tasksPath := filepath.Join(dir, "tasks.jsonl")
+	outputPath := filepath.Join(dir, "report.json")
+	if err := os.WriteFile(tasksPath, []byte(`{"id":"dry","prompt":"Say hello","expected_contains":["codex"]}
+`), 0o600); err != nil {
+		t.Fatalf("write tasks: %v", err)
+	}
+
+	var out strings.Builder
+	err := run(context.Background(), runConfig{
+		CodexCommand: "codex",
+		TasksPath:    tasksPath,
+		Mode:         "native",
+		Workdir:      dir,
+		OutputPath:   outputPath,
+		RawDir:       "",
+		Runs:         1,
+		Timeout:      time.Second,
+		DryRun:       true,
+	}, &out)
+	if err != nil {
+		t.Fatalf("run dry-run: %v", err)
+	}
+	if !strings.Contains(out.String(), "dry native run 1") || !strings.Contains(out.String(), "wrote "+outputPath) {
+		t.Fatalf("unexpected output:\n%s", out.String())
+	}
+
+	var rep report
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	if err := json.Unmarshal(data, &rep); err != nil {
+		t.Fatalf("unmarshal report: %v", err)
+	}
+	if len(rep.Results) != 1 {
+		t.Fatalf("report results = %d, want 1", len(rep.Results))
+	}
+	if !strings.Contains(rep.Results[0].FinalAnswer, "codex --search exec") {
+		t.Fatalf("dry-run final answer = %q, want command line", rep.Results[0].FinalAnswer)
 	}
 }
 
@@ -189,6 +256,33 @@ func TestRawEventsPath(t *testing.T) {
 	}
 }
 
+func TestWriteRawEventsCreatesParentDirectory(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "raw", "events.jsonl")
+
+	if err := writeRawEvents(path, []byte("event\n")); err != nil {
+		t.Fatalf("writeRawEvents: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read raw events: %v", err)
+	}
+	if string(got) != "event\n" {
+		t.Fatalf("raw events = %q, want event newline", got)
+	}
+	if err := writeRawEvents("", []byte("ignored")); err != nil {
+		t.Fatalf("writeRawEvents empty path: %v", err)
+	}
+}
+
+func TestSanitizeFilenameFallbackAndCompaction(t *testing.T) {
+	if got := sanitizeFilename("  Hello, World!  "); got != "hello-world" {
+		t.Fatalf("sanitizeFilename = %q, want hello-world", got)
+	}
+	if got := sanitizeFilename("!!!"); got != "run" {
+		t.Fatalf("sanitizeFilename punctuation = %q, want run", got)
+	}
+}
+
 func TestComparePairsReportsRatios(t *testing.T) {
 	pairs := comparePairs([]result{
 		{TaskID: "one", Mode: "native", DurationMS: 100, Metrics: eventMetrics{TotalTokens: 200}},
@@ -218,5 +312,68 @@ func TestMCPNoopSuccess(t *testing.T) {
 	r.Metrics.ToolCalls = 1
 	if isSuccessful(r) {
 		t.Fatal("expected mcp_noop with tool calls to fail")
+	}
+}
+
+func TestEvaluateHintsReportsMissingExpectedContent(t *testing.T) {
+	hints := evaluateHints(task{
+		ExpectedContains:    []string{"readinessProbe", "livenessProbe"},
+		ExpectedURLContains: []string{"/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/"},
+	}, "Use readinessProbe for readiness checks.", "https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/")
+
+	if hints.AnswerContainsMatched {
+		t.Fatal("expected answer hints not to fully match")
+	}
+	if len(hints.MissingAnswerContains) != 1 || hints.MissingAnswerContains[0] != "livenessProbe" {
+		t.Fatalf("missing answer hints = %#v", hints.MissingAnswerContains)
+	}
+	if !hints.URLContainsMatched {
+		t.Fatalf("expected URL hint to match, missing %#v", hints.MissingURLContains)
+	}
+}
+
+func TestSummarizeComputesMediansAndSuccessRate(t *testing.T) {
+	summaries := summarize([]result{
+		{
+			Mode:       "native",
+			DurationMS: 300,
+			ExitCode:   0,
+			Metrics:    eventMetrics{InputTokens: 30, TotalTokens: 300, ToolCalls: 2},
+			CorrectHints: hintResult{
+				AnswerContainsMatched: true,
+				URLContainsMatched:    true,
+			},
+		},
+		{
+			Mode:       "native",
+			DurationMS: 100,
+			ExitCode:   1,
+			Metrics:    eventMetrics{InputTokens: 10, TotalTokens: 100, ToolCalls: 1},
+			CorrectHints: hintResult{
+				AnswerContainsMatched: true,
+				URLContainsMatched:    true,
+			},
+		},
+		{
+			Mode:       "native",
+			DurationMS: 200,
+			ExitCode:   0,
+			Metrics:    eventMetrics{InputTokens: 20, TotalTokens: 200, ToolCalls: 3},
+			CorrectHints: hintResult{
+				AnswerContainsMatched: true,
+				URLContainsMatched:    true,
+			},
+		},
+	})
+
+	if len(summaries) != 1 {
+		t.Fatalf("summaries = %d, want 1", len(summaries))
+	}
+	got := summaries[0]
+	if got.Runs != 3 || got.MedianDurationMS != 200 || got.MedianInputTokens != 20 || got.MedianTotalTokens != 200 || got.MedianToolCalls != 2 {
+		t.Fatalf("unexpected summary: %+v", got)
+	}
+	if got.Successes != 2 || got.SuccessRate != 2.0/3.0 {
+		t.Fatalf("success summary = %d/%f, want 2/%f", got.Successes, got.SuccessRate, 2.0/3.0)
 	}
 }

--- a/cmd/documcp/main_test.go
+++ b/cmd/documcp/main_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"encoding/base64"
+	"encoding/hex"
+	"strings"
 	"testing"
 )
 
@@ -17,5 +20,54 @@ func TestBindAddr_EnvOverride(t *testing.T) {
 	got := bindAddr(8080)
 	if got != "0.0.0.0:9090" {
 		t.Fatalf("bindAddr with override = %q, want 0.0.0.0:9090", got)
+	}
+}
+
+func TestDeriveKey_HexSecret(t *testing.T) {
+	want := []byte("12345678901234567890123456789012")
+	t.Setenv("DOCUMCP_SECRET_KEY", hex.EncodeToString(want))
+
+	got := deriveKey()
+	if string(got) != string(want) {
+		t.Fatalf("deriveKey() = %x, want %x", got, want)
+	}
+}
+
+func TestDeriveKey_Base64Secret(t *testing.T) {
+	want := []byte("abcdefghijklmnopqrstuvwxyz123456")
+	t.Setenv("DOCUMCP_SECRET_KEY", base64.StdEncoding.EncodeToString(want))
+
+	got := deriveKey()
+	if string(got) != string(want) {
+		t.Fatalf("deriveKey() = %q, want %q", got, want)
+	}
+}
+
+func TestDeriveKey_URLBase64Secret(t *testing.T) {
+	want := []byte(strings.Repeat("\xff", 32))
+	t.Setenv("DOCUMCP_SECRET_KEY", base64.URLEncoding.EncodeToString(want))
+
+	got := deriveKey()
+	if string(got) != string(want) {
+		t.Fatalf("deriveKey() = %x, want %x", got, want)
+	}
+}
+
+func TestDeriveKey_InvalidSecretFallsBackToEphemeralKey(t *testing.T) {
+	t.Setenv("DOCUMCP_SECRET_KEY", "not-a-valid-32-byte-key")
+
+	got := deriveKey()
+	if len(got) != 32 {
+		t.Fatalf("deriveKey() length = %d, want 32", len(got))
+	}
+}
+
+func TestGetenv(t *testing.T) {
+	t.Setenv("DOCUMCP_TEST_VALUE", "configured")
+	if got := getenv("DOCUMCP_TEST_VALUE", "default"); got != "configured" {
+		t.Fatalf("getenv existing = %q, want configured", got)
+	}
+	if got := getenv("DOCUMCP_TEST_MISSING", "default"); got != "default" {
+		t.Fatalf("getenv missing = %q, want default", got)
 	}
 }

--- a/internal/adapter/adapter_test.go
+++ b/internal/adapter/adapter_test.go
@@ -1,0 +1,47 @@
+package adapter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mathwro/DocuMcp/internal/config"
+	"github.com/mathwro/DocuMcp/internal/db"
+)
+
+type registryTestAdapter struct{}
+
+func (registryTestAdapter) Crawl(context.Context, config.SourceConfig, int64) (int, <-chan db.Page, <-chan error, error) {
+	pages := make(chan db.Page)
+	errs := make(chan error)
+	close(pages)
+	close(errs)
+	return 0, pages, errs, nil
+}
+
+func (registryTestAdapter) NeedsAuth(config.SourceConfig) bool { return false }
+
+func TestRegisterAddsAdapterToRegistry(t *testing.T) {
+	const sourceType = "registry_test"
+	original, hadOriginal := Registry[sourceType]
+	t.Cleanup(func() {
+		if hadOriginal {
+			Registry[sourceType] = original
+		} else {
+			delete(Registry, sourceType)
+		}
+	})
+
+	adapter := registryTestAdapter{}
+	Register(sourceType, adapter)
+
+	got, ok := Registry[sourceType]
+	if !ok {
+		t.Fatal("registered adapter missing from registry")
+	}
+	if got == nil {
+		t.Fatal("registered adapter is nil")
+	}
+	if got.NeedsAuth(config.SourceConfig{}) {
+		t.Fatal("registered adapter returned unexpected NeedsAuth result")
+	}
+}

--- a/internal/adapter/azuredevops/azuredevops_test.go
+++ b/internal/adapter/azuredevops/azuredevops_test.go
@@ -51,3 +51,10 @@ func TestAzureDevOpsAdapter_CrawlsWikiPages(t *testing.T) {
 		t.Fatalf("expected 2 pages, got %d", len(pages))
 	}
 }
+
+func TestAzureDevOpsAdapter_NeedsAuth(t *testing.T) {
+	a := azuredevops.NewAdapter("")
+	if !a.NeedsAuth(config.SourceConfig{Type: "azure_devops"}) {
+		t.Fatal("NeedsAuth = false, want true")
+	}
+}

--- a/internal/adapter/github/github_test.go
+++ b/internal/adapter/github/github_test.go
@@ -53,3 +53,10 @@ func TestGitHubAdapter_CrawlsWikiPages(t *testing.T) {
 		t.Fatalf("expected 2 pages (Home + Authentication Guide), got %d", len(pages))
 	}
 }
+
+func TestGitHubAdapter_NeedsAuth(t *testing.T) {
+	a := github.NewAdapter("https://api.github.com")
+	if !a.NeedsAuth(config.SourceConfig{Type: "github_wiki", Repo: "owner/repo"}) {
+		t.Fatal("NeedsAuth = false, want true")
+	}
+}

--- a/internal/adapter/githubrepo/githubrepo_test.go
+++ b/internal/adapter/githubrepo/githubrepo_test.go
@@ -29,6 +29,13 @@ func TestAdapterRegistered(t *testing.T) {
 	}
 }
 
+func TestAdapter_NeedsAuth(t *testing.T) {
+	a := githubrepo.NewAdapter("https://api.github.com")
+	if !a.NeedsAuth(config.SourceConfig{Type: "github_repo", Repo: "owner/repo"}) {
+		t.Fatal("NeedsAuth = false, want true")
+	}
+}
+
 // buildTarball produces a gzipped tar archive whose entries are prefixed
 // with "owner-repo-sha/", mimicking GitHub's tarball output.
 func buildTarball(t *testing.T, prefix string, entries map[string][]byte) []byte {

--- a/internal/adapter/web/web_test.go
+++ b/internal/adapter/web/web_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -38,6 +39,84 @@ func TestCrawl_IncludePath_InvalidURL(t *testing.T) {
 	}, 1)
 	if err == nil {
 		t.Fatal("expected error for invalid include_path, got nil")
+	}
+}
+
+func TestNeedsAuthRequiresConfiguredAuth(t *testing.T) {
+	a := &WebAdapter{}
+	if a.NeedsAuth(config.SourceConfig{}) {
+		t.Fatal("NeedsAuth without auth = true, want false")
+	}
+	if !a.NeedsAuth(config.SourceConfig{Auth: "basic"}) {
+		t.Fatal("NeedsAuth with auth = false, want true")
+	}
+}
+
+func TestCrawlRequiresSourceURL(t *testing.T) {
+	a := &WebAdapter{}
+	_, pages, errs, err := a.Crawl(context.Background(), config.SourceConfig{Type: "web"}, 1)
+	if err == nil {
+		t.Fatal("expected missing URL error, got nil")
+	}
+	if pages != nil || errs != nil {
+		t.Fatalf("expected nil channels on setup error, got pages=%v errs=%v", pages, errs)
+	}
+}
+
+func TestCrawlFallsBackToSourceURLWhenNoLinksDiscovered(t *testing.T) {
+	withLookup(t, map[string][]net.IP{
+		"docs.example.com": {net.ParseIP("1.2.3.4")},
+	})
+	restore := replaceCrawlClient(&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Header.Get("User-Agent") != crawlUserAgent {
+			t.Fatalf("User-Agent = %q, want %q", req.Header.Get("User-Agent"), crawlUserAgent)
+		}
+		switch req.URL.Path {
+		case "/docs/sitemap.xml", "/sitemap.xml":
+			return response(req, http.StatusNotFound, "text/xml", ""), nil
+		case "/docs/":
+			return response(req, http.StatusOK, "text/html", `<html><body><h1>Docs Home</h1><p>Welcome.</p></body></html>`), nil
+		default:
+			return response(req, http.StatusNotFound, "text/plain", ""), nil
+		}
+	})})
+	defer restore()
+
+	a := &WebAdapter{}
+	total, pages, errs, err := a.Crawl(context.Background(), config.SourceConfig{
+		Type: "web",
+		URL:  "https://docs.example.com/docs/",
+	}, 7)
+	if err != nil {
+		t.Fatalf("Crawl: %v", err)
+	}
+	if total != 1 {
+		t.Fatalf("total = %d, want 1", total)
+	}
+
+	var got []dbPage
+	for page := range pages {
+		got = append(got, dbPage{
+			SourceID: page.SourceID,
+			URL:      page.URL,
+			Title:    page.Title,
+			Content:  page.Content,
+			Path:     page.Path,
+		})
+	}
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("crawl error: %v", err)
+		}
+	}
+	if len(got) != 1 {
+		t.Fatalf("pages = %#v, want one page", got)
+	}
+	if got[0].SourceID != 7 || got[0].URL != "https://docs.example.com/docs/" || got[0].Title != "Docs Home" {
+		t.Fatalf("unexpected page: %#v", got[0])
+	}
+	if !reflect.DeepEqual(got[0].Path, []string{"docs"}) {
+		t.Fatalf("page path = %#v, want [docs]", got[0].Path)
 	}
 }
 
@@ -261,6 +340,108 @@ func TestFetchPage_ReturnsBlockedErrorForCloudflareChallenge(t *testing.T) {
 	}
 }
 
+func TestFetchPageParsesTitleContentAndPath(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Header.Get("User-Agent") != crawlUserAgent {
+			t.Fatalf("User-Agent = %q, want %q", req.Header.Get("User-Agent"), crawlUserAgent)
+		}
+		return response(req, http.StatusOK, "text/html", `<html><body><h1>Install Guide</h1><p>Run the installer.</p></body></html>`), nil
+	})}
+
+	page, err := fetchPage(context.Background(), client, "https://docs.example.com/docs/install", 42, mustParseURL("https://docs.example.com/docs/"))
+	if err != nil {
+		t.Fatalf("fetchPage: %v", err)
+	}
+	if page.SourceID != 42 || page.URL != "https://docs.example.com/docs/install" || page.Title != "Install Guide" {
+		t.Fatalf("unexpected page metadata: %#v", page)
+	}
+	if !strings.Contains(page.Content, "Run the installer.") {
+		t.Fatalf("content = %q, want extracted body text", page.Content)
+	}
+	if !reflect.DeepEqual(page.Path, []string{"docs", "install"}) {
+		t.Fatalf("path = %#v, want docs/install", page.Path)
+	}
+}
+
+func TestFetchPageReturnsErrorForNonOKResponse(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return response(req, http.StatusNotFound, "text/plain", "missing"), nil
+	})}
+
+	_, err := fetchPage(context.Background(), client, "https://docs.example.com/missing", 1, mustParseURL("https://docs.example.com/"))
+	if err == nil || !strings.Contains(err.Error(), "non-200") {
+		t.Fatalf("fetchPage error = %v, want non-200 error", err)
+	}
+}
+
+func TestFetchPageRetriesOnceAfterRateLimit(t *testing.T) {
+	calls := 0
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			resp := response(req, http.StatusTooManyRequests, "text/plain", "slow down")
+			resp.Header.Set("Retry-After", "0")
+			return resp, nil
+		}
+		return response(req, http.StatusOK, "text/html", `<html><body><h1>Retried</h1><p>Loaded.</p></body></html>`), nil
+	})}
+
+	page, err := fetchPage(context.Background(), client, "https://docs.example.com/retry", 9, mustParseURL("https://docs.example.com/"))
+	if err != nil {
+		t.Fatalf("fetchPage: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("calls = %d, want 2", calls)
+	}
+	if page.Title != "Retried" || page.SourceID != 9 {
+		t.Fatalf("page = %#v", page)
+	}
+}
+
+func TestFetchPageFallsBackToURLTitle(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return response(req, http.StatusOK, "text/html", `<html><body></body></html>`), nil
+	})}
+
+	page, err := fetchPage(context.Background(), client, "https://docs.example.com/untitled", 1, mustParseURL("https://docs.example.com/"))
+	if err != nil {
+		t.Fatalf("fetchPage: %v", err)
+	}
+	if page.Title != "https://docs.example.com/untitled" {
+		t.Fatalf("Title = %q, want page URL fallback", page.Title)
+	}
+}
+
+func TestDiscoverSitemapURLsUsesFirstNonEmptyCandidate(t *testing.T) {
+	restore := replaceCrawlClient(&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.String() {
+		case "https://docs.example.com/docs/sitemap.xml":
+			return response(req, http.StatusNotFound, "text/xml", ""), nil
+		case "https://docs.example.com/sitemap.xml":
+			return response(req, http.StatusOK, "text/xml", `<?xml version="1.0"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://docs.example.com/docs/page</loc></url>
+</urlset>`), nil
+		default:
+			return response(req, http.StatusNotFound, "text/plain", ""), nil
+		}
+	})})
+	defer restore()
+
+	got := discoverSitemapURLs(context.Background(), "https://docs.example.com/docs", mustParseURL("https://docs.example.com/docs"))
+	want := []string{"https://docs.example.com/docs/page"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("discoverSitemapURLs = %#v, want %#v", got, want)
+	}
+}
+
+func TestURLToPathRootUsesHome(t *testing.T) {
+	got := urlToPath(mustParseURL("https://docs.example.com/"), mustParseURL("https://docs.example.com/"))
+	if !reflect.DeepEqual(got, []string{"Home"}) {
+		t.Fatalf("urlToPath root = %#v, want Home", got)
+	}
+}
+
 func mustParseURL(raw string) *url.URL {
 	u, err := url.Parse(raw)
 	if err != nil {
@@ -273,4 +454,31 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
+}
+
+type dbPage struct {
+	SourceID int64
+	URL      string
+	Title    string
+	Content  string
+	Path     []string
+}
+
+func replaceCrawlClient(client *http.Client) func() {
+	original := crawlClient
+	crawlClient = client
+	return func() { crawlClient = original }
+}
+
+func response(req *http.Request, status int, contentType string, body string) *http.Response {
+	header := make(http.Header)
+	if contentType != "" {
+		header.Set("Content-Type", contentType)
+	}
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     header,
+		Request:    req,
+	}
 }

--- a/internal/api/handlers_internal_test.go
+++ b/internal/api/handlers_internal_test.go
@@ -12,6 +12,76 @@ import (
 	"github.com/mathwro/DocuMcp/internal/testutil"
 )
 
+func TestIsLoopbackOrigin(t *testing.T) {
+	cases := []struct {
+		origin string
+		want   bool
+	}{
+		{origin: "http://localhost:8080", want: true},
+		{origin: "https://127.0.0.1:3000", want: true},
+		{origin: "http://[::1]:8080", want: true},
+		{origin: "https://192.168.1.10:3000", want: false},
+		{origin: "https://example.com", want: false},
+		{origin: "not a url", want: false},
+	}
+	for _, tc := range cases {
+		if got := isLoopbackOrigin(tc.origin); got != tc.want {
+			t.Fatalf("isLoopbackOrigin(%q) = %v, want %v", tc.origin, got, tc.want)
+		}
+	}
+}
+
+func TestSecurityMiddlewareAddsHeadersAndAllowsLoopbackCORS(t *testing.T) {
+	nextCalled := false
+	handler := securityMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusTeapot)
+	}))
+
+	r := httptest.NewRequest(http.MethodGet, "/api/sources", nil)
+	r.Header.Set("Origin", "http://localhost:5173")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if !nextCalled {
+		t.Fatal("expected wrapped handler to be called")
+	}
+	if w.Code != http.StatusTeapot {
+		t.Fatalf("status = %d, want 418", w.Code)
+	}
+	if w.Header().Get("X-Content-Type-Options") != "nosniff" {
+		t.Fatalf("missing security headers: %#v", w.Header())
+	}
+	if w.Header().Get("Access-Control-Allow-Origin") != "http://localhost:5173" {
+		t.Fatalf("Access-Control-Allow-Origin = %q, want loopback origin", w.Header().Get("Access-Control-Allow-Origin"))
+	}
+	if w.Header().Get("Vary") != "Origin" {
+		t.Fatalf("Vary = %q, want Origin", w.Header().Get("Vary"))
+	}
+}
+
+func TestSecurityMiddlewareOmitsCORSForExternalOriginAndHandlesPreflight(t *testing.T) {
+	nextCalled := false
+	handler := securityMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+	}))
+
+	r := httptest.NewRequest(http.MethodOptions, "/api/sources", nil)
+	r.Header.Set("Origin", "https://example.com")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if nextCalled {
+		t.Fatal("OPTIONS preflight should not call wrapped handler")
+	}
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", w.Code)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("Access-Control-Allow-Origin = %q, want empty for external origin", got)
+	}
+}
+
 // TestTriggerCrawl_Returns409WhenAlreadyCrawling verifies that a second crawl
 // request for a source already marked in-flight returns 409 Conflict instead
 // of silently spawning a second goroutine.

--- a/internal/auth/microsoft.go
+++ b/internal/auth/microsoft.go
@@ -13,6 +13,11 @@ import (
 // No app registration required — works across all tenants without admin consent.
 const AzureCLIClientID = "04b07795-8ddb-461a-bbee-02f9e1bf7b46"
 
+var (
+	postForm  = http.PostForm
+	pollAfter = time.After
+)
+
 // MicrosoftDeviceFlow holds state for an in-progress device code flow.
 type MicrosoftDeviceFlow struct {
 	DeviceCode      string
@@ -27,7 +32,7 @@ type MicrosoftDeviceFlow struct {
 // and tenant. For production use: baseURL="https://login.microsoftonline.com", tenant="consumers".
 func NewMicrosoftDeviceFlow(baseURL, tenant string) (*MicrosoftDeviceFlow, error) {
 	endpoint := fmt.Sprintf("%s/%s/oauth2/v2.0/devicecode", baseURL, tenant)
-	resp, err := http.PostForm(endpoint, url.Values{
+	resp, err := postForm(endpoint, url.Values{
 		"client_id": {AzureCLIClientID},
 		"scope":     {"https://management.azure.com/user_impersonation offline_access"},
 	})
@@ -72,10 +77,10 @@ func (f *MicrosoftDeviceFlow) Poll(ctx context.Context) (*Token, error) {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
-		case <-time.After(time.Duration(interval) * time.Second):
+		case <-pollAfter(time.Duration(interval) * time.Second):
 		}
 
-		resp, err := http.PostForm(f.tokenEndpoint, url.Values{
+		resp, err := postForm(f.tokenEndpoint, url.Values{
 			"client_id":   {AzureCLIClientID},
 			"grant_type":  {"urn:ietf:params:oauth:grant-type:device_code"},
 			"device_code": {f.DeviceCode},

--- a/internal/auth/microsoft_internal_test.go
+++ b/internal/auth/microsoft_internal_test.go
@@ -1,0 +1,102 @@
+package auth
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestMicrosoftDeviceFlowPollReturnsTokenAfterPending(t *testing.T) {
+	restore := stubPollDependencies(t, []pollResponse{
+		{body: `{"error":"authorization_pending"}`},
+		{body: `{"access_token":"access","refresh_token":"refresh","expires_in":3600}`},
+	})
+	defer restore()
+
+	flow := &MicrosoftDeviceFlow{
+		DeviceCode:    "device-code",
+		Interval:      1,
+		tokenEndpoint: "https://login.example/token",
+	}
+	token, err := flow.Poll(context.Background())
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if token.AccessToken != "access" || token.RefreshToken != "refresh" {
+		t.Fatalf("token = %#v", token)
+	}
+	if time.Until(token.ExpiresAt) <= 0 {
+		t.Fatalf("ExpiresAt = %v, want future time", token.ExpiresAt)
+	}
+}
+
+func TestMicrosoftDeviceFlowPollReturnsAuthError(t *testing.T) {
+	restore := stubPollDependencies(t, []pollResponse{
+		{body: `{"error":"expired_token"}`},
+	})
+	defer restore()
+
+	flow := &MicrosoftDeviceFlow{DeviceCode: "device-code", tokenEndpoint: "https://login.example/token"}
+	_, err := flow.Poll(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "expired_token") {
+		t.Fatalf("Poll error = %v, want expired_token auth error", err)
+	}
+}
+
+func TestMicrosoftDeviceFlowPollReturnsContextError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	flow := &MicrosoftDeviceFlow{DeviceCode: "device-code", tokenEndpoint: "https://login.example/token"}
+	_, err := flow.Poll(ctx)
+	if err != context.Canceled {
+		t.Fatalf("Poll error = %v, want context.Canceled", err)
+	}
+}
+
+type pollResponse struct {
+	body string
+}
+
+func stubPollDependencies(t *testing.T, responses []pollResponse) func() {
+	t.Helper()
+	originalAfter := pollAfter
+	originalPostForm := postForm
+	pollAfter = func(time.Duration) <-chan time.Time {
+		ch := make(chan time.Time, 1)
+		ch <- time.Now()
+		return ch
+	}
+	call := 0
+	postForm = func(endpoint string, values url.Values) (*http.Response, error) {
+		if endpoint != "https://login.example/token" {
+			t.Fatalf("endpoint = %q, want token endpoint", endpoint)
+		}
+		if values.Get("client_id") != AzureCLIClientID {
+			t.Fatalf("client_id = %q, want Azure CLI client ID", values.Get("client_id"))
+		}
+		if values.Get("grant_type") != "urn:ietf:params:oauth:grant-type:device_code" {
+			t.Fatalf("grant_type = %q", values.Get("grant_type"))
+		}
+		if values.Get("device_code") != "device-code" {
+			t.Fatalf("device_code = %q", values.Get("device_code"))
+		}
+		if call >= len(responses) {
+			t.Fatalf("unexpected poll call %d", call+1)
+		}
+		resp := responses[call]
+		call++
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(resp.body)),
+			Header:     make(http.Header),
+		}, nil
+	}
+	return func() {
+		pollAfter = originalAfter
+		postForm = originalPostForm
+	}
+}

--- a/internal/crawler/scheduler_test.go
+++ b/internal/crawler/scheduler_test.go
@@ -1,0 +1,90 @@
+package crawler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mathwro/DocuMcp/internal/config"
+	"github.com/mathwro/DocuMcp/internal/testutil"
+)
+
+func TestNewSchedulerInitializesCancelableContext(t *testing.T) {
+	store := testutil.OpenStore(t)
+	s := NewScheduler(New(store, nil), store)
+	defer func() {
+		ctx := s.Stop()
+		<-ctx.Done()
+	}()
+
+	if s.cron == nil {
+		t.Fatal("cron is nil")
+	}
+	if s.crawler == nil {
+		t.Fatal("crawler is nil")
+	}
+	if s.store == nil {
+		t.Fatal("store is nil")
+	}
+	select {
+	case <-s.ctx.Done():
+		t.Fatal("scheduler context is canceled before Stop")
+	default:
+	}
+}
+
+func TestSchedulerLoadRegistersOnlyValidScheduledSources(t *testing.T) {
+	store := testutil.OpenStore(t)
+	s := NewScheduler(New(store, nil), store)
+	defer func() {
+		ctx := s.Stop()
+		<-ctx.Done()
+	}()
+
+	s.Load(&config.Config{Sources: []config.SourceConfig{
+		{Name: "unscheduled", Type: "web"},
+		{Name: "scheduled", Type: "web", CrawlSchedule: "0 0 * * *"},
+		{Name: "invalid", Type: "web", CrawlSchedule: "not cron"},
+	}})
+
+	if got := len(s.cron.Entries()); got != 1 {
+		t.Fatalf("registered cron entries = %d, want 1", got)
+	}
+}
+
+func TestSchedulerLoadReplacesExistingSchedule(t *testing.T) {
+	store := testutil.OpenStore(t)
+	s := NewScheduler(New(store, nil), store)
+	defer func() {
+		ctx := s.Stop()
+		<-ctx.Done()
+	}()
+
+	s.Load(&config.Config{Sources: []config.SourceConfig{
+		{Name: "first", Type: "web", CrawlSchedule: "0 0 * * *"},
+	}})
+	s.Load(&config.Config{Sources: []config.SourceConfig{
+		{Name: "second", Type: "web", CrawlSchedule: "0 1 * * *"},
+		{Name: "third", Type: "web", CrawlSchedule: "0 2 * * *"},
+	}})
+
+	if got := len(s.cron.Entries()); got != 2 {
+		t.Fatalf("registered cron entries after reload = %d, want 2", got)
+	}
+}
+
+func TestSchedulerStopCancelsBaseContext(t *testing.T) {
+	store := testutil.OpenStore(t)
+	s := NewScheduler(New(store, nil), store)
+
+	done := s.Stop()
+	select {
+	case <-s.ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("scheduler base context was not canceled")
+	}
+	select {
+	case <-done.Done():
+	case <-time.After(time.Second):
+		t.Fatal("cron stop context was not canceled")
+	}
+}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -286,6 +286,36 @@ func TestUpdateSourcePageCount(t *testing.T) {
 	}
 }
 
+func TestUpdateSourceCrawlTotal(t *testing.T) {
+	store := testutil.OpenStore(t)
+
+	id, err := store.InsertSource(db.Source{Name: "S", Type: "web"})
+	if err != nil {
+		t.Fatalf("InsertSource: %v", err)
+	}
+	if err := store.UpdateSourceCrawlTotal(id, 27); err != nil {
+		t.Fatalf("UpdateSourceCrawlTotal: %v", err)
+	}
+	got, err := store.GetSource(id)
+	if err != nil {
+		t.Fatalf("GetSource: %v", err)
+	}
+	if got.CrawlTotal != 27 {
+		t.Fatalf("CrawlTotal = %d, want 27", got.CrawlTotal)
+	}
+}
+
+func TestStoreDBReturnsUnderlyingDatabase(t *testing.T) {
+	store := testutil.OpenStore(t)
+
+	if store.DB() == nil {
+		t.Fatal("DB() = nil, want underlying database")
+	}
+	if err := store.DB().Ping(); err != nil {
+		t.Fatalf("DB().Ping: %v", err)
+	}
+}
+
 func TestGetSource(t *testing.T) {
 	store := testutil.OpenStore(t)
 
@@ -340,6 +370,27 @@ func TestUpsertAndGetToken(t *testing.T) {
 	}
 	if string(data) != string(tokenData) {
 		t.Errorf("expected %q, got %q", tokenData, data)
+	}
+}
+
+func TestDeleteToken(t *testing.T) {
+	store := testutil.OpenStore(t)
+
+	srcID, err := store.InsertSource(db.Source{Name: "S", Type: "web"})
+	if err != nil {
+		t.Fatalf("InsertSource: %v", err)
+	}
+	if err := store.UpsertToken(srcID, "github", []byte("encrypted"), time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("UpsertToken: %v", err)
+	}
+	if err := store.DeleteToken(srcID, "github"); err != nil {
+		t.Fatalf("DeleteToken: %v", err)
+	}
+	if _, err := store.GetToken(srcID, "github"); !errors.Is(err, db.ErrNotFound) {
+		t.Fatalf("GetToken after delete error = %v, want ErrNotFound", err)
+	}
+	if err := store.DeleteToken(srcID, "github"); err != nil {
+		t.Fatalf("DeleteToken missing token: %v", err)
 	}
 }
 

--- a/internal/embed/embedder.go
+++ b/internal/embed/embedder.go
@@ -12,8 +12,16 @@ import (
 
 // Embedder wraps a hugot feature extraction pipeline.
 type Embedder struct {
-	session  *hugot.Session
-	pipeline *pipelines.FeatureExtractionPipeline
+	session  sessionDestroyer
+	pipeline embeddingPipeline
+}
+
+type sessionDestroyer interface {
+	Destroy() error
+}
+
+type embeddingPipeline interface {
+	RunPipeline([]string) (*pipelines.FeatureExtractionOutput, error)
 }
 
 // New creates an Embedder backed by the ONNX model at modelPath.

--- a/internal/embed/embedder_internal_test.go
+++ b/internal/embed/embedder_internal_test.go
@@ -1,0 +1,75 @@
+package embed
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/knights-analytics/hugot/pipelines"
+)
+
+type fakePipeline struct {
+	output *pipelines.FeatureExtractionOutput
+	err    error
+}
+
+func (f *fakePipeline) RunPipeline(_ []string) (*pipelines.FeatureExtractionOutput, error) {
+	return f.output, f.err
+}
+
+type fakeSession struct {
+	err       error
+	destroyed bool
+}
+
+func (f *fakeSession) Destroy() error {
+	f.destroyed = true
+	return f.err
+}
+
+func TestEmbedCopiesPipelineEmbeddings(t *testing.T) {
+	embedding := []float32{1, 2, 3}
+	e := &Embedder{
+		pipeline: &fakePipeline{output: &pipelines.FeatureExtractionOutput{
+			Embeddings: [][]float32{embedding},
+		}},
+	}
+
+	got, err := e.Embed([]string{"hello"})
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d vectors, want 1", len(got))
+	}
+	if got[0][0] != 1 || got[0][1] != 2 || got[0][2] != 3 {
+		t.Fatalf("Embed() = %#v", got)
+	}
+
+	embedding[0] = 99
+	if got[0][0] != 1 {
+		t.Fatalf("Embed returned aliased vector; got[0][0] = %v, want 1", got[0][0])
+	}
+}
+
+func TestEmbedWrapsPipelineError(t *testing.T) {
+	e := &Embedder{pipeline: &fakePipeline{err: errors.New("pipeline failed")}}
+
+	_, err := e.Embed([]string{"hello"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, e.pipeline.(*fakePipeline).err) {
+		t.Fatalf("Embed error = %v, want wrapped pipeline error", err)
+	}
+}
+
+func TestCloseDestroysSession(t *testing.T) {
+	session := &fakeSession{}
+	e := &Embedder{session: session}
+
+	e.Close()
+
+	if !session.destroyed {
+		t.Fatal("Close did not destroy session")
+	}
+}

--- a/internal/search/semantic.go
+++ b/internal/search/semantic.go
@@ -2,15 +2,19 @@ package search
 
 import (
 	"fmt"
+	"reflect"
 
 	"github.com/mathwro/DocuMcp/internal/db"
-	"github.com/mathwro/DocuMcp/internal/embed"
 )
+
+type queryEmbedder interface {
+	Embed([]string) ([][]float32, error)
+}
 
 // Semantic runs a nearest-neighbour vector search using sqlite-vec.
 // Returns nil, nil when embedder is nil — caller skips semantic search gracefully.
-func Semantic(store *db.Store, embedder *embed.Embedder, query string, limit int) ([]Result, error) {
-	if embedder == nil {
+func Semantic(store *db.Store, embedder queryEmbedder, query string, limit int) ([]Result, error) {
+	if isNilEmbedder(embedder) {
 		return nil, nil
 	}
 	vecs, err := embedder.Embed([]string{query})
@@ -40,4 +44,17 @@ func Semantic(store *db.Store, embedder *embed.Embedder, query string, limit int
 		return nil, fmt.Errorf("scan semantic results: %w", err)
 	}
 	return results, nil
+}
+
+func isNilEmbedder(embedder queryEmbedder) bool {
+	if embedder == nil {
+		return true
+	}
+	v := reflect.ValueOf(embedder)
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return v.IsNil()
+	default:
+		return false
+	}
 }

--- a/internal/search/semantic_test.go
+++ b/internal/search/semantic_test.go
@@ -1,0 +1,84 @@
+package search
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/mathwro/DocuMcp/internal/db"
+	"github.com/mathwro/DocuMcp/internal/testutil"
+)
+
+type fakeEmbedder struct {
+	vecs [][]float32
+	err  error
+}
+
+func (f fakeEmbedder) Embed(texts []string) ([][]float32, error) {
+	if len(texts) != 1 || texts[0] != "oauth setup" {
+		return nil, errors.New("unexpected query")
+	}
+	return f.vecs, f.err
+}
+
+func TestSemanticReturnsNilWhenEmbedderMissing(t *testing.T) {
+	store := testutil.OpenStore(t)
+
+	results, err := Semantic(store, nil, "oauth setup", 5)
+	if err != nil {
+		t.Fatalf("Semantic: %v", err)
+	}
+	if results != nil {
+		t.Fatalf("results = %#v, want nil when embedder is missing", results)
+	}
+}
+
+func TestSemanticWrapsEmbedError(t *testing.T) {
+	store := testutil.OpenStore(t)
+	wantErr := errors.New("embedding failed")
+
+	_, err := Semantic(store, fakeEmbedder{err: wantErr}, "oauth setup", 5)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Semantic error = %v, want wrapped embed error", err)
+	}
+}
+
+func TestSemanticReturnsNearestEmbeddingResults(t *testing.T) {
+	store := testutil.OpenStore(t)
+	srcID, err := store.InsertSource(db.Source{Name: "Docs", Type: "web"})
+	if err != nil {
+		t.Fatalf("InsertSource: %v", err)
+	}
+	pageID, err := store.UpsertPage(db.Page{
+		SourceID: srcID,
+		URL:      "https://docs.example.com/oauth",
+		Title:    "OAuth Setup",
+		Content:  "<p>" + strings.Repeat("OAuth setup uses device code flow. ", 30) + "</p>",
+		Path:     []string{"Auth", "OAuth"},
+	})
+	if err != nil {
+		t.Fatalf("UpsertPage: %v", err)
+	}
+	vec := make([]float32, 384)
+	vec[0] = 1
+	if err := store.UpsertEmbedding(pageID, vec); err != nil {
+		t.Fatalf("UpsertEmbedding: %v", err)
+	}
+
+	results, err := Semantic(store, fakeEmbedder{vecs: [][]float32{vec}}, "oauth setup", 1)
+	if err != nil {
+		t.Fatalf("Semantic: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results = %d, want 1", len(results))
+	}
+	if results[0].URL != "https://docs.example.com/oauth" || results[0].Title != "OAuth Setup" {
+		t.Fatalf("unexpected result: %#v", results[0])
+	}
+	if strings.Contains(results[0].Snippet, "<p>") {
+		t.Fatalf("snippet contains HTML tags: %q", results[0].Snippet)
+	}
+	if len(results[0].Snippet) > snippetMaxChars+3 {
+		t.Fatalf("snippet length = %d, want truncated snippet", len(results[0].Snippet))
+	}
+}


### PR DESCRIPTION
## Summary

- Adds focused tests across adapters, web crawling, API security middleware, auth polling, search semantic behavior, DB helpers, scheduler lifecycle, embedder wrapper behavior, and benchmark helpers.
- Introduces small test seams for Microsoft device-flow polling and semantic-search embedder injection while preserving production behavior.
- Raises total statement coverage from the initial 59.6%% to 72.3%%.

## Validation

- `CGO_ENABLED=1 GOCACHE=/tmp/documcp-go-build go test -tags sqlite_fts5 -coverprofile=coverage.out ./...`

## Notes

- Draft PR so the coverage-focused changes can be reviewed before marking ready.
